### PR TITLE
Tell PyPI that long_description is Markdown

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -190,7 +190,7 @@ setup(
         "(GPLv2+)"
         ],
     long_description=long_description,
-    long_description_content_type="text/markdown"
+    long_description_content_type="text/markdown",
     author_email="eugen.wintersberger@desy.de, dominik.kriegner@gmail.com",
     maintainer="Dominik Kriegner",
     maintainer_email="dominik.kriegner@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -190,6 +190,7 @@ setup(
         "(GPLv2+)"
         ],
     long_description=long_description,
+    long_description_content_type="text/markdown"
     author_email="eugen.wintersberger@desy.de, dominik.kriegner@gmail.com",
     maintainer="Dominik Kriegner",
     maintainer_email="dominik.kriegner@gmail.com",


### PR DESCRIPTION
The description on PyPI looks like this:

![image](https://user-images.githubusercontent.com/1324225/68214587-65fab180-ffe6-11e9-9357-46bf7c8770a4.png)

Adding this metadata means it will show the Markdown properly, like GitHub does.

Make sure to use recent tools, eg.:

```
pip install -U setuptools twine wheel
```

More info:

* https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi/