### PR TITLE
Stop using legacy bdist_wininst

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,7 +47,7 @@ install:
       python -m pip install --upgrade tox
 
 build_script:
-  - cmd: IF DEFINED MINICONDA ( echo "Build step skipped" ) ELSE ( python setup.py bdist_wheel bdist_wininst )
+  - cmd: IF DEFINED MINICONDA ( echo "Build step skipped" ) ELSE ( python setup.py bdist_wheel )
 
 test_script:
   - cmd: IF DEFINED MINICONDA ( tox ) ELSE ( echo "Tests skipped" )

--- a/release.txt
+++ b/release.txt
@@ -80,7 +80,7 @@ To build a wheel for Microsoft Windows run
   python setup.py bdist_wheel
 
 on a Windows machine.
-If not done previously you need to build the extention modules using
+If not done previously you need to build the extension modules using
 
   python setup.py build -c <compiler_name>
 

--- a/release.txt
+++ b/release.txt
@@ -75,12 +75,12 @@ the installation of xrayutilities
 
 This tarball should be uploaded to sourceforge and PyPI.
 
-To build a executable installer for Microsoft windows run
+To build a wheel for Microsoft Windows run
 
-  python setup.py bdist_wininst
+  python setup.py bdist_wheel
 
-on a windows machine.
-If not done previously you need to build the extenstion modules using
+on a Windows machine.
+If not done previously you need to build the extention modules using
 
   python setup.py build -c <compiler_name>
 
@@ -94,7 +94,7 @@ following steps:
  * (optional) execute: 'setenv /x64 /release' (use /x86 for a 32-bit build)
  * compile with: 'python setup.py build'. one might need to use
    '--without-openmp' option for building.
- * build binaries with 'python setup.py bdist_wininst bdist_wheel'
+ * build binaries with 'python setup.py bdist_wheel'
  * install package locally 'python setup.py install'
  * use 'python setup.py test' to test your installation
 


### PR DESCRIPTION
The `bdist_wininst` file type is deprecated by PyPI:

* https://www.python.org/dev/peps/pep-0527/

It will probably be removed soon:

* https://github.com/pypa/warehouse/issues/6792
