### PR TITLE
remove dependency on soon deprecated distutils

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+* remove dependency on soon deprecated distutils
+* fix regression bug with matplotlib 3.5
 * update copyright notices from git commit history
 * fix code error found by linting (flake8)
 * CIF atom type normalization of oxidation state (issue #122)

--- a/README.md
+++ b/README.md
@@ -71,13 +71,9 @@ installation path.
 
 By default the installation procedure tries to enable OpenMP support
 (recommended). It is disabled silently if OpenMP is not available. It can also
-be disable by using the *--without-openmp* option for the installation:
+be disabled by using the *--without-openmp* option for the installation:
 
-    pip install --global-option="--without-openmp" xrayutilities
-
-or
-
-    python setup.py --without-openmp install
+    python setup.py build_ext --without-openmp install
 
 Requirements
 ------------

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ import sys
 import tempfile
 
 import numpy
+import setuptools
 from setuptools import Extension, find_packages, setup
 from setuptools.command.build_ext import build_ext
 from setuptools.command.build_py import build_py


### PR DESCRIPTION
distutils will be deprecated https://www.python.org/dev/peps/pep-0632/

Therefore it should be removed from setup.py. It is mostly replaced by equivalent setuptools functionality.
