### PR TITLE
allow newer sphinx version for builddocs

### DIFF
--- a/.azure/azure-builddocs.yml
+++ b/.azure/azure-builddocs.yml
@@ -24,7 +24,7 @@ steps:
   displayName: 'Install build dependencies'
 
 - script: |
-    pip install matplotlib numpydoc rst2pdf sphinx==3.5.4 sphinx_rtd_theme svglib
+    pip install matplotlib numpydoc rst2pdf sphinx sphinx_rtd_theme svglib
   displayName: 'Install documentation dependencies'
 
 - script: pip install .

--- a/doc/webpage.patch
+++ b/doc/webpage.patch
@@ -1,14 +1,14 @@
---- build/sphinx/html/index.html.orig	2021-11-23 11:01:20.000000000 +0100
-+++ build/sphinx/html/index.html	2021-11-23 11:06:32.949289041 +0100
-@@ -82,6 +82,7 @@
+--- build/sphinx/html/index.html.orig	2022-03-03 17:41:08.481169450 +0100
++++ build/sphinx/html/index.html	2022-03-03 17:46:43.226602844 +0100
+@@ -87,6 +87,7 @@
  <a class="reference external image-reference" href="https://dev.azure.com/dominikkriegner/xrayutilities/_build"><img alt="Unit test status" src="https://dev.azure.com/dominikkriegner/xrayutilities/_apis/build/status/tox-testing?repoName=dkriegner%2Fxrayutilities&amp;branchName=main" /></a>
  <p>If you look for downloading the package go to <a class="reference external" href="https://sourceforge.net/projects/xrayutilities">Sourceforge</a> or <a class="reference external" href="https://github.com/dkriegner/xrayutilities">GitHub</a> (source distribution) or the <a class="reference external" href="https://pypi.python.org/pypi/xrayutilities">Python package index</a> (MS Windows binary).</p>
  <p>Read more about <em>xrayutilities</em> below or in <a class="reference external" href="http://dx.doi.org/10.1107/S0021889813017214">Journal of Applied Crystallography 2013, Volume 46, 1162-1170</a></p>
 +<p>This documentation can also be downloaded in <a href="xrayutilities.pdf">PDF format</a>.</p>
- </div>
- <div class="section" id="installation">
+ </section>
+ <section id="installation">
  <h1>Installation<a class="headerlink" href="#installation" title="Permalink to this headline">¶</a></h1>
-@@ -624,4 +625,4 @@
+@@ -538,4 +539,4 @@
    </script> 
  
  </body>


### PR DESCRIPTION
the old one seems to fail one python 3.10.