### PR TITLE
allow float for cch1 and cch2

### DIFF
--- a/lib/xrayutilities/experiment.py
+++ b/lib/xrayutilities/experiment.py
@@ -862,8 +862,8 @@ class QConversion(object):
         # other none keyword arguments
         self._area_Nch1 = int(Nch1)
         self._area_Nch2 = int(Nch2)
-        self._area_cch1 = int(cch1)
-        self._area_cch2 = int(cch2)
+        self._area_cch1 = float(cch1)
+        self._area_cch2 = float(cch2)
 
         # if detector rotation is present add new motor to consider it in
         # conversion


### PR DESCRIPTION
Hi Dominik, 

mir ist aufgefallen, dass cch1 und cch2 auf int gesetzt werden obwohl die c-Routine auch float nehmen würde. Bei kleinen Winkeln machen 0.5 Pixel schon manchmal ganz schön was aus. Wäre cool wenn du das mit upstream nehmen könntest.

Viele Grüße,
Tobias (Ritschel) 