### PR TITLE
remove build_doc command in setup.py

### DIFF
--- a/.azure/azure-builddocs.yml
+++ b/.azure/azure-builddocs.yml
@@ -35,7 +35,7 @@ steps:
   displayName: 'Generating API documentation'
 
 - script: |
-    python setup.py build_doc -b html
+    sphinx-build -b html doc/source build/sphinx/html
   displayName: 'Generating HTML documentation'
 
 - script: |
@@ -48,7 +48,7 @@ steps:
   displayName: 'Patch HTML documentation for webpage'
 
 - script: |
-    python setup.py build build_doc -b pdf
+    sphinx-build -b pdf doc/source build/sphinx/pdf
     cp build/sphinx/pdf/xrayutilities.pdf build/sphinx/html/
   displayName: 'Generating PDF documentation'
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+* remove build_doc target for setup.py, use sphinx (see builddocs pipeline)
+
 v1.7.4, 2022-10-31
 
 * fix data type casting of cch1,2 in QConversion.init_area -> these can now be floating point values (#141 by @trdd)

--- a/setup.py
+++ b/setup.py
@@ -128,32 +128,6 @@ extmodul = Extension('xrayutilities.cxrayutilities',
 with open('lib/xrayutilities/VERSION') as version_file:
     version = version_file.read().strip().replace('\n', '.')
 
-try:
-    import sphinx
-    from sphinx.setup_command import BuildDoc
-
-    class build_doc(BuildDoc):
-        def run(self):
-            # make sure the python path is pointing to the newly built
-            # code so that the documentation is built on this and not a
-            # previously installed version
-            build = self.get_finalized_command('build')
-            sys.path.insert(0, os.path.abspath(build.build_lib))
-            try:
-                sphinx.setup_command.BuildDoc.run(self)
-            except UnicodeDecodeError:
-                print("ERROR: unable to build documentation"
-                      " because Sphinx do not handle"
-                      " source path with non-ASCII characters. Please"
-                      " try to move the source package to another"
-                      " location (path with *only* ASCII characters)")
-            sys.path.pop(0)
-
-    cmdclass['build_doc'] = build_doc
-
-except ImportError:
-    pass
-
 setup(
     name="xrayutilities",
     version=version,


### PR DESCRIPTION
this feature was introduced ~10years ago for Debian packaging which abandoned it already. I see no reason to keep it around any longer.