### PR TITLE
use plain pytest on azure, remove tox

### DIFF
--- a/.azure/azure-buildwheels.yml
+++ b/.azure/azure-buildwheels.yml
@@ -3,8 +3,8 @@ name: $(Date:yyyyMMdd)$(Rev:rr)
 # trigger build only after successful test on main-branch
 resources:
   pipelines:
-  - pipeline: tox-testing
-    source: tox-testing
+  - pipeline: testing
+    source: testing
     trigger:
       branches:
         include:

--- a/.azure/azure-testing.yml
+++ b/.azure/azure-testing.yml
@@ -8,42 +8,23 @@ trigger:
     include:
       - v*
 
-resources:
-  repositories:
-  - repository: tox
-    type: github
-    endpoint: github
-    name: tox-dev/azure-pipelines-template
-    ref: master
 
 jobs:
-- template: run-tox-env.yml@tox
+- template: templates/testing_job.yml
   parameters:
-    tox_version: 'tox tox-wheel'
-    jobs:
-      py310:
-        before:
-          - task: Cache@2
-            inputs:
-              key: testdata20190812
-              path: $(System.DefaultWorkingDirectory)/tests/data
-              cacheHitVar: TESTDATA_RESTORED
-            displayName: Cache test data
-          - script: |
-              curl -s -L https://sourceforge.net/projects/xrayutilities/files/xrayutilities-testdata-20190812.tar.gz -o xu_testdata.tar.gz
-              tar xzf xu_testdata.tar.gz -C tests
-            condition: ne(variables.TESTDATA_RESTORED, 'true')
-            displayName: Download test data
-        image: [linux, windows, macOs]
-      py39:
-        image: [linux, windows, macOs]
-      py38:
-        image: [linux, windows, macOs]
-      py37:
-        image: [linux, windows, macOs]
-    coverage:
-      with_toxenv: 'coverage'
-      for_envs: [py37, py38, py39, py310]
+    name: Linux
+    vmImage: 'ubuntu-latest'
+
+- template: templates/testing_job.yml
+  parameters:
+    name: macOS
+    vmImage: 'macOS-latest'
+
+- template: templates/testing_job.yml
+  parameters:
+    name: Windows
+    vmImage: 'windows-latest'
+
 
 schedules:
 - cron: "0 4 1 * *"

--- a/.azure/templates/testing_job.yml
+++ b/.azure/templates/testing_job.yml
@@ -1,0 +1,49 @@
+parameters:
+- name: name
+  default: ''
+- name: vmImage
+  default: ''
+
+jobs:
+-job: ${{ parameters.name }}
+  pool:
+    vmImage: ${{ parameters.vmImage }}
+  strategy:
+    matrix:
+      Python37:
+        python.version: '3.7'
+      Python38:
+        python.version: '3.8'
+      Python39:
+        python.version: '3.9'
+      Python310:
+        python.version: '3.10'
+
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+  - task: Cache@2
+    inputs:
+      key: testdata20190812
+      path: $(System.DefaultWorkingDirectory)/tests/data
+      cacheHitVar: TESTDATA_RESTORED
+    condition: and(succeeded(), eq(variables['python.version'], '3.10'))
+    displayName: Cache test data
+  - script: |
+      curl -s -L https://sourceforge.net/projects/xrayutilities/files/xrayutilities-testdata-20190812.tar.gz -o xu_testdata.tar.gz
+      tar xzf xu_testdata.tar.gz -C tests
+    condition: and(succeeded(), ne(variables['TESTDATA_RESTORED'], 'true'), eq(variables['python.version'], '3.10'))
+    displayName: Download test data
+  - script: |
+      pip install -r recommended_requirements.txt
+    displayName: Install requirements
+  - script: |
+      pip install coverage[toml] pytest pytest-cov pytest-azurepipelines
+    displayName: Install test requirements
+  - script: |
+      pip install .[plot,fit]
+  - script: |
+      pytest --cov --cov-config pyproject.toml --cov-report html
+    displayName: Run pytest
+

--- a/.azure/templates/testing_job.yml
+++ b/.azure/templates/testing_job.yml
@@ -43,6 +43,7 @@ jobs:
     displayName: Install test requirements
   - script: |
       pip install .[plot,fit]
+    displayName: Install xrayutilities
   - script: |
       pytest --cov --cov-config pyproject.toml --cov-report html
     displayName: Run pytest

--- a/.azure/templates/testing_job.yml
+++ b/.azure/templates/testing_job.yml
@@ -45,6 +45,15 @@ jobs:
       pip install .[plot,fit]
     displayName: Install xrayutilities
   - script: |
-      pytest --cov --cov-config pyproject.toml --cov-report html
+      pytest --junitxml=junit/test-results.xml --cov --cov-config pyproject.toml --cov-report=xml
     displayName: Run pytest
+  - task: PublishTestResults@2
+    condition: succeededOrFailed()
+    inputs:
+      testResultsFiles: '**/test-*.xml'
+      testRunTitle: 'Publish test results for Python $(python.version)'
+  - task: PublishCodeCoverageResults@1
+    inputs:
+      codeCoverageTool: Cobertura
+      summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
 

--- a/.azure/templates/testing_job.yml
+++ b/.azure/templates/testing_job.yml
@@ -5,7 +5,7 @@ parameters:
   default: ''
 
 jobs:
--job: ${{ parameters.name }}
+- job: ${{ parameters.name }}
   pool:
     vmImage: ${{ parameters.vmImage }}
   strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,3 @@ dist/
 build/
 MANIFEST
 xrayutilities.egg-info/
-
-# test coverage data
-.coverage
-.coverage.*
-htmlcov
-.tox

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+* use plain pytest in the CI integration (no code change in the package)
 * remove build_doc target for setup.py, use sphinx (see builddocs pipeline)
 
 v1.7.4, 2022-10-31

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ When building from source you also might need:
 - C-compiler (preferential with OpenMP support)
 - Python dev headers
 - setuptools
-- tox (optional - only if you want to run the test environment)
+- pytest (optional - only if you want to run the test environment)
 - sphinx (optional - only when you want to build the documentation)
 - numpydoc (optional - only when you want to build the documentation)
 - rst2pdf (optional - only when you want to build the documentation)

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -23,7 +23,7 @@ Welcome to xrayutilities's documentation!
   .. image:: https://img.shields.io/pypi/l/xrayutilities.svg
      :target: https://pypi.python.org/pypi/xrayutilities/
      :alt: License
-  .. image:: https://dev.azure.com/dominikkriegner/xrayutilities/_apis/build/status/tox-testing?repoName=dkriegner%2Fxrayutilities&branchName=main
+  .. image:: https://dev.azure.com/dominikkriegner/xrayutilities/_apis/build/status/testing?repoName=dkriegner%2Fxrayutilities&branchName=main
      :target: https://dev.azure.com/dominikkriegner/xrayutilities/_build
      :alt: Unit test status
 
@@ -209,7 +209,7 @@ Additionally, the following Python modules are needed when building *xrayutiliti
  * **C-compiler** Gnu Compiler Collection or any compatible C compiler. On windows you most probably want to use the Microsoft compilers.
  * **Python development headers**
  * **setuptools** build system
- * **tox** needed for running the pre-configured unittest environment, which in principal can also be achieved only by the unittest package (optional)
+ * **pytest** needed for running the pre-configured unittest environment, which in principal can also be achieved only by the unittest package (optional)
 
 For building the documention (which you do not need to do) the requirements are:
  * **sphinx** the Python documentation generator

--- a/doc/webpage.patch
+++ b/doc/webpage.patch
@@ -1,7 +1,7 @@
 --- build/sphinx/html/index.html.orig	2022-03-03 17:41:08.481169450 +0100
 +++ build/sphinx/html/index.html	2022-03-03 17:46:43.226602844 +0100
 @@ -87,6 +87,7 @@
- <a class="reference external image-reference" href="https://dev.azure.com/dominikkriegner/xrayutilities/_build"><img alt="Unit test status" src="https://dev.azure.com/dominikkriegner/xrayutilities/_apis/build/status/tox-testing?repoName=dkriegner%2Fxrayutilities&amp;branchName=main" /></a>
+ <a class="reference external image-reference" href="https://dev.azure.com/dominikkriegner/xrayutilities/_build"><img alt="Unit test status" src="https://dev.azure.com/dominikkriegner/xrayutilities/_apis/build/status/testing?repoName=dkriegner%2Fxrayutilities&amp;branchName=main" /></a>
  <p>If you look for downloading the package go to <a class="reference external" href="https://sourceforge.net/projects/xrayutilities">Sourceforge</a> or <a class="reference external" href="https://github.com/dkriegner/xrayutilities">GitHub</a> (source distribution) or the <a class="reference external" href="https://pypi.python.org/pypi/xrayutilities">Python package index</a> (MS Windows binary).</p>
  <p>Read more about <em>xrayutilities</em> below or in <a class="reference external" href="http://dx.doi.org/10.1107/S0021889813017214">Journal of Applied Crystallography 2013, Volume 46, 1162-1170</a></p>
 +<p>This documentation can also be downloaded in <a href="xrayutilities.pdf">PDF format</a>.</p>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,34 +14,3 @@ parallel = true
 source = [
     "xrayutilities"
 ]
-
-[tool.tox]
-legacy_tox_ini = """
-[tox]
-envlist = py{36,37,38,39,310},coverage
-distshare = {toxinidir}/dist
-
-[testenv]
-wheel = true
-allowlist_externals =
-    mv
-deps =
-    h5py
-    lmfit
-    matplotlib
-    numpy
-    scipy
-    pytest
-    pytest-cov
-    coverage[toml]
-commands =
-    pytest --cov --cov-config pyproject.toml --junitxml=.tox/junit.{envname}.xml --cov-report=xml:.tox/coverage.xml
-    mv .coverage .tox/.coverage.{envname}
-
-[testenv:coverage]
-commands =
-    coverage combine .tox/
-    coverage xml -i -o .tox/coverage.xml
-    coverage report -i
-    mv .coverage .tox/
-"""

--- a/recommended_requirements.txt
+++ b/recommended_requirements.txt
@@ -1,0 +1,7 @@
+# minimal requirements
+numpy
+scipy
+h5py
+# recommended packages
+lmfit
+matplotlib

--- a/release.txt
+++ b/release.txt
@@ -20,7 +20,7 @@ lib/xrayutilities/math/fit.py:192:80: E501 line too long (90 > 79 characters)
 lib/xrayutilities/math/fit.py:266:80: E501 line too long (90 > 79 characters)
 lib/xrayutilities/math/fit.py:307:80: E501 line too long (90 > 79 characters)
   # run the unit tests
-  tox
+  pytest
 
 
 PACKAGING


### PR DESCRIPTION
So far [tox](https://tox.wiki/en/latest/) was used for the testing since I used it consistently some time also locally on my development system. I do not do that anymore for some time and the way it was used on Azure got problematic since the used template caused errors and also was slow to adapt new Python versions (in fact I had to submit a PR for that)

This PR removes tox for testing in the CI. 

Note that tox was never a dependency of xrayutilities but merely used in the CI pipelines