### PR TITLE
make C-code respect the VERBOSITY setting

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+* remove set_bit/clear_bit functions in favor of using enum.IntFlag
 * use plain pytest in the CI integration (no code change in the package)
 * remove build_doc target for setup.py, use sphinx (see builddocs pipeline)
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+* make C-code respect the VERBOSITY. C-Code should now be silent with
+  VERBOSITY<INFO_ALL. Otherwise lots of info is printed. #145
 * remove set_bit/clear_bit functions in favor of using enum.IntFlag
 * use plain pytest in the CI integration (no code change in the package)
 * remove build_doc target for setup.py, use sphinx (see builddocs pipeline)

--- a/lib/xrayutilities/__init__.py
+++ b/lib/xrayutilities/__init__.py
@@ -38,8 +38,8 @@ from .gridder3d import FuzzyGridder3D, Gridder3D
 from .normalize import (IntensityNormalizer, blockAverage1D, blockAverage2D,
                         blockAverageCCD, blockAveragePSD)
 from .q2ang_fit import Q2AngFit
-from .utilities import (clear_bit, en2lam, energy, frac2str, lam2en,
-                        makeNaturalName, maplog, set_bit, wavelength)
+from .utilities import (en2lam, energy, frac2str, lam2en, makeNaturalName,
+                        maplog, wavelength)
 
 # load package version
 with open(os.path.join(__path__[0], 'VERSION')) as version_file:

--- a/lib/xrayutilities/experiment.py
+++ b/lib/xrayutilities/experiment.py
@@ -14,7 +14,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Copyright (C) 2009-2010 Eugen Wintersberger <eugen.wintersberger@desy.de>
-# Copyright (C) 2009-2021 Dominik Kriegner <dominik.kriegner@gmail.com>
+# Copyright (C) 2009-2023 Dominik Kriegner <dominik.kriegner@gmail.com>
 # Copyright (C) 2012 Tanja Etzelstorfer <tanja.etzelstorfer@jku.at>
 
 """
@@ -28,6 +28,7 @@ configured to describe almost any goniometer geometry.
 """
 
 import copy
+import enum
 import numbers
 import re
 import warnings
@@ -43,6 +44,13 @@ from .exception import InputError
 directionSyntax = re.compile("[xyz][+-]")
 circleSyntaxDetector = re.compile("([xyz][+-])|(t[xyz])")
 circleSyntaxSample = re.compile("[xyzk][+-]")
+
+
+class QConvFlags(enum.IntFlag):
+    NONE = 0
+    HAS_TRANSLATIONS = 1
+    HAS_SAMPLEDIS = 4
+    VERBOSE = 16
 
 
 class QConversion(object):
@@ -443,9 +451,9 @@ class QConversion(object):
             sample displacement vector in relative units of the detector
             distance. Applies to parallel beam geometry. (default: (0, 0, 0))
         """
-        flags = 0
+        flags = QConvFlags.NONE
         if self._has_translations:
-            flags = utilities.set_bit(flags, 0)
+            flags |= QConvFlags.HAS_TRANSLATIONS
 
         Ns = len(self.sampleAxis)
         Nd = len(self.detectorAxis)
@@ -470,7 +478,7 @@ class QConversion(object):
 
         sd = numpy.asarray(kwargs.get('sampledis', [0, 0, 0]))
         if 'sampledis' in kwargs:
-            flags = utilities.set_bit(flags, 2)
+            flags |= QConvFlags.HAS_SAMPLEDIS
 
         return Ns, Nd, Ncirc, wl, deg, delta, UB, sd, flags
 

--- a/lib/xrayutilities/gridder2d.py
+++ b/lib/xrayutilities/gridder2d.py
@@ -226,7 +226,7 @@ class FuzzyGridder2D(Gridder2D):
             wx = delta(self.xmin, self.xmax, self.nx) / 2.
             wy = delta(self.ymin, self.ymax, self.ny) / 2.
         # remove normalize flag for C-code
-        flags = self.flags > GridderFlags.NO_NORMALIZATION
+        flags = self.flags | GridderFlags.NO_NORMALIZATION
         cxrayutilities.fuzzygridder2d(x, y, data, self.nx, self.ny,
                                       self.xmin, self.xmax,
                                       self.ymin, self.ymax,

--- a/lib/xrayutilities/gridder2d.py
+++ b/lib/xrayutilities/gridder2d.py
@@ -21,7 +21,7 @@
 import numpy
 
 from . import cxrayutilities, exception, utilities
-from .gridder import Gridder, axis, delta, ones
+from .gridder import Gridder, GridderFlags, axis, delta, ones
 
 
 class Gridder2D(Gridder):
@@ -168,7 +168,7 @@ class Gridder2D(Gridder):
         """
         x, y, data = self._checktransinput(x, y, data)
         # remove normalize flag for C-code
-        flags = utilities.set_bit(self.flags, 2)
+        flags = self.flags | GridderFlags.NO_NORMALIZATION
         cxrayutilities.gridder2d(x, y, data, self.nx, self.ny,
                                  self.xmin, self.xmax,
                                  self.ymin, self.ymax,
@@ -226,7 +226,7 @@ class FuzzyGridder2D(Gridder2D):
             wx = delta(self.xmin, self.xmax, self.nx) / 2.
             wy = delta(self.ymin, self.ymax, self.ny) / 2.
         # remove normalize flag for C-code
-        flags = utilities.set_bit(self.flags, 2)
+        flags = self.flags > GridderFlags.NO_NORMALIZATION
         cxrayutilities.fuzzygridder2d(x, y, data, self.nx, self.ny,
                                       self.xmin, self.xmax,
                                       self.ymin, self.ymax,

--- a/lib/xrayutilities/gridder3d.py
+++ b/lib/xrayutilities/gridder3d.py
@@ -21,7 +21,7 @@
 import numpy
 
 from . import cxrayutilities, exception, utilities
-from .gridder import Gridder, axis, delta, ones
+from .gridder import Gridder, GridderFlags, axis, delta, ones
 
 
 class Gridder3D(Gridder):
@@ -165,7 +165,7 @@ class Gridder3D(Gridder):
         x, y, z, data = self._checktransinput(x, y, z, data)
 
         # remove normalize flag for C-code
-        flags = utilities.set_bit(self.flags, 2)
+        flags = self.flags | GridderFlags.NO_NORMALIZATION
         cxrayutilities.gridder3d(x, y, z, data, self.nx, self.ny, self.nz,
                                  self.xmin, self.xmax,
                                  self.ymin, self.ymax,
@@ -228,7 +228,7 @@ class FuzzyGridder3D(Gridder3D):
             wz = delta(self.zmin, self.zmax, self.nz) / 2.
 
         # remove normalize flag for C-code
-        flags = utilities.set_bit(self.flags, 2)
+        flags = self.flags | GridderFlags.NO_NORMALIZATION
         cxrayutilities.fuzzygridder3d(x, y, z, data, self.nx, self.ny, self.nz,
                                       self.xmin, self.xmax,
                                       self.ymin, self.ymax,

--- a/lib/xrayutilities/utilities_noconf.py
+++ b/lib/xrayutilities/utilities_noconf.py
@@ -36,9 +36,9 @@ except AttributeError:  # Python 2.7
     ABC = abc.ABCMeta('ABC', (object, ), {'__slots__': ()})
 
 
-__all__ = ['ABC', 'check_kwargs', 'clear_bit', 'en2lam', 'energies', 'energy',
+__all__ = ['ABC', 'check_kwargs', 'en2lam', 'energies', 'energy',
            'exchange_filepath', 'exchange_path', 'is_valid_variable_name',
-           'lam2en', 'makeNaturalName', 'set_bit', 'wavelength']
+           'lam2en', 'makeNaturalName', 'wavelength']
 
 energies = {
     'CuKa1': 8047.82310,
@@ -58,22 +58,6 @@ energies = {
 # Xray data booklet:
 # CoKa1
 # CoKa2
-
-
-def set_bit(f, offset):
-    """
-    sets the bit at an offset
-    """
-    mask = 1 << offset
-    return (f | mask)
-
-
-def clear_bit(f, offset):
-    """
-    clears the bet at an offset
-    """
-    mask = ~(1 << offset)
-    return (f & mask)
 
 
 def lam2en(inp):

--- a/src/gridder1d.c
+++ b/src/gridder1d.c
@@ -179,14 +179,16 @@ int fuzzygridder1d(double *x, double *data, unsigned int n,
 
     /* warn the user in case more than half the data points where out
      *  of the gridding area */
-    if (noutofbounds > n / 2) {
-        fprintf(stdout, "XU.FuzzyGridder1D(c): more than half of the "
+    if (flags & VERBOSE) {
+        if (noutofbounds > n / 2) {
+            fprintf(stdout, "XU.FuzzyGridder1D(c): more than half of the "
                         "datapoints out of the data range, consider regridding"
                         " with extended range!\n");
-    }
-    else if (flags & VERBOSE) {
-        fprintf(stdout, "XU.FuzzyGridder1D(c): %d datapoints out of the data "
+        }
+        else {
+            fprintf(stdout, "XU.FuzzyGridder1D(c): %d datapoints out of the data "
                         "range!\n", noutofbounds);
+        }
     }
 
     return 0;
@@ -320,10 +322,16 @@ int gridder1d(double *x, double *data, unsigned int n,
 
     /* warn the user in case more than half the data points where out
      *  of the gridding area */
-    if (noutofbounds > n / 2) {
-        fprintf(stdout, "XU.Gridder1D(c): more than half of the datapoints "
-                        "out of the data range, consider regridding with "
-                        "extended range!\n");
+    if (flags & VERBOSE) {
+        if (noutofbounds > n / 2) {
+            fprintf(stdout, "XU.Gridder1D(c): more than half of the "
+                        "datapoints out of the data range, consider regridding"
+                        " with extended range!\n");
+        }
+        else {
+            fprintf(stdout, "XU.Gridder1D(c): %d datapoints out of the data "
+                        "range!\n", noutofbounds);
+        }
     }
 
     return 0;

--- a/src/gridder2d.c
+++ b/src/gridder2d.c
@@ -225,10 +225,16 @@ int fuzzygridder2d(double *x, double *y, double *data, unsigned int n,
 
     /* warn the user in case more than half the data points where out
      * of the gridding area */
-    if (noutofbounds > n / 2) {
-        fprintf(stdout,"XU.FuzzyGridder2D(c): more than half of the datapoints"
+    if (flags & VERBOSE) {
+        if (noutofbounds > n / 2) {
+            fprintf(stdout,"XU.FuzzyGridder2D(c): more than half of the datapoints"
                         " out of the data range, consider regridding with"
                         " extended range!\n");
+        }
+        else {
+            fprintf(stdout, "XU.FuzzyGridder2D(c): %d datapoints out of the data "
+                        "range!\n", noutofbounds);
+        }
     }
 
     return 0;
@@ -379,10 +385,16 @@ int gridder2d(double *x, double *y, double *data, unsigned int n,
 
     /* warn the user in case more than half the data points where out
      * of the gridding area */
-    if (noutofbounds > n / 2) {
-        fprintf(stdout,"XU.Gridder2D(c): more than half of the datapoints out "
-                        "of the data range, consider regridding with extended "
-                        "range!\n");
+    if (flags & VERBOSE) {
+        if (noutofbounds > n / 2) {
+            fprintf(stdout,"XU.Gridder2D(c): more than half of the datapoints"
+                        " out of the data range, consider regridding with"
+                        " extended range!\n");
+        }
+        else {
+            fprintf(stdout, "XU.Gridder2D(c): %d datapoints out of the data "
+                        "range!\n", noutofbounds);
+        }
     }
 
     return 0;

--- a/src/gridder3d.c
+++ b/src/gridder3d.c
@@ -255,10 +255,16 @@ int fuzzygridder3d(double *x, double *y, double *z, double *data,
 
     /* warn the user in case more than half the data points where out
      * of the gridding area */
-    if (noutofbounds > n / 2) {
-        fprintf(stdout, "XU.FuzzyGridder3D(c): more than half of the "
-                "datapoints out of the data range, consider regridding with "
-                "extended range!\n");
+    if (flags & VERBOSE) {
+        if (noutofbounds > n / 2) {
+            fprintf(stdout,"XU.FuzzyGridder3D(c): more than half of the datapoints"
+                        " out of the data range, consider regridding with"
+                        " extended range!\n");
+        }
+        else {
+            fprintf(stdout, "XU.FuzzyGridder3D(c): %d datapoints out of the data "
+                        "range!\n", noutofbounds);
+        }
     }
 
     return 0;
@@ -416,10 +422,16 @@ int gridder3d(double *x, double *y, double *z, double *data, unsigned int n,
 
     /* warn the user in case more than half the data points where out
      * of the gridding area */
-    if (noutofbounds > n / 2) {
-        fprintf(stdout, "XU.Gridder3D(c): more than half of the datapoints "
-                "out of the data range, consider regridding with extended "
-                "range!\n");
+    if (flags & VERBOSE) {
+        if (noutofbounds > n / 2) {
+            fprintf(stdout,"XU.Gridder3D(c): more than half of the datapoints"
+                        " out of the data range, consider regridding with"
+                        " extended range!\n");
+        }
+        else {
+            fprintf(stdout, "XU.Gridder3D(c): %d datapoints out of the data "
+                        "range!\n", noutofbounds);
+        }
     }
 
     return 0;

--- a/tests/test_materials.py
+++ b/tests/test_materials.py
@@ -32,9 +32,8 @@ class TestMaterialsTransform(unittest.TestCase):
         cls.c11, cls.c12, cls.c44 = numpy.random.rand(3) * 1e10
         cls.p1mat = xu.materials.Crystal(
             'P1', xu.materials.SGLattice(1, cls.a, cls.b, cls.c,
-                                         cls.alpha, cls.beta, cls.gamma), 
-                                         xu.materials.CubicElasticTensor(
-                                         cls.c11, cls.c12, cls.c44))
+                                         cls.alpha, cls.beta, cls.gamma),
+            xu.materials.CubicElasticTensor(cls.c11, cls.c12, cls.c44))
 
     def test_q2hkl_hkl2q(self):
         for i in range(3):
@@ -130,25 +129,25 @@ class TestMaterialsTransform(unittest.TestCase):
             self.assertFalse(mat.lattice.isequivalent(hkl1, hkl2s[1]))
 
     def test_Strain(self):
-        strain = numpy.zeros((3,3), dtype=numpy.double)
-        strain[0,0:3] = numpy.random.rand(3)
-        strain[1,1:3] = numpy.random.rand(2)
-        strain[2,2] = numpy.random.rand(1)
-        strain[0:3,0] = strain[0,0:3]
-        strain[1:3,1] = strain[1,1:3]
+        strain = numpy.zeros((3, 3), dtype=numpy.double)
+        strain[0, 0:3] = numpy.random.rand(3)
+        strain[1, 1:3] = numpy.random.rand(2)
+        strain[2, 2] = numpy.random.rand(1)
+        strain[0:3, 0] = strain[0, 0:3]
+        strain[1:3, 1] = strain[1, 1:3]
 
         stress = self.p1mat.GetStress(strain)
         strain_rev = self.p1mat.GetStrain(stress)
         numpy.testing.assert_almost_equal(strain, strain_rev)
 
     def test_Stress(self):
-        stress = numpy.zeros((3,3), dtype=numpy.double)
-        stress[0,0:3] = numpy.random.rand(3)
-        stress[1,1:3] = numpy.random.rand(2)
-        stress[2,2] = numpy.random.rand(1)
-        stress[0:3,0] = stress[0,0:3]
-        stress[1:3,1] = stress[1,1:3]
-        
+        stress = numpy.zeros((3, 3), dtype=numpy.double)
+        stress[0, 0:3] = numpy.random.rand(3)
+        stress[1, 1:3] = numpy.random.rand(2)
+        stress[2, 2] = numpy.random.rand(1)
+        stress[0:3, 0] = stress[0, 0:3]
+        stress[1:3, 1] = stress[1, 1:3]
+
         strain = self.p1mat.GetStrain(stress)
         stress_rev = self.p1mat.GetStress(strain)
         numpy.testing.assert_almost_equal(stress, stress_rev)


### PR DESCRIPTION
With the default settings no printouts should occur now from the C-code. 

If `xrayutilities.config.VERBOSITY >= 2` (`xrayutilities.config.INFO_ALL`) some debug output will occur from the C-code of the Gridders. This includes the warning when more than half the points are out of the gridding range and several other debug outputs.

At the same time the python implementation of the correspond flag is changed to used the enum.IntFlag class from the standard library