### PR TITLE
enable naming of simulation materials

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+* allow naming of simulation materials (Powder, Layer)
 * example script for fitting diffraction data of an epitaxial multilayer (by @VeryBitter)
 * update AlAs lattice parameters from APL 66, 682 (1995) (by @VeryBitter)
 * enable building Python 3.11 wheels

--- a/lib/xrayutilities/simpack/smaterials.py
+++ b/lib/xrayutilities/simpack/smaterials.py
@@ -47,7 +47,7 @@ class SMaterial:
     needed for simulations
     """
 
-    def __init__(self, material, **kwargs):
+    def __init__(self, material, name=None, **kwargs):
         """
         initialize a simulation material by specifiying its Material and
         optional other properties
@@ -57,10 +57,15 @@ class SMaterial:
         material :  Material (Crystal, or Amorphous)
             Material object containing optical/crystal properties of for the
             simulation; a deepcopy is used internally.
+        name : str, optional
+            name of the material used in the simulations
         kwargs :    dict
             optional properties of the material needed for the simulation
         """
-        self.name = utilities.makeNaturalName(material.name, check=True)
+        if name is not None:
+            self.name = utilities.makeNaturalName(name, check=True)
+        else:
+            self.name = utilities.makeNaturalName(material.name, check=True)
         self.material = copy.deepcopy(material)
         for kw in kwargs:
             setattr(self, kw, kwargs[kw])
@@ -136,7 +141,7 @@ class SMaterial:
     __rmul__ = __mul__
 
     def __repr__(self):
-        s = f'{self.__class__.__name__}-{self.material.name} ('
+        s = f'{self.__class__.__name__}-{self.name} ('
         for k in self.__dict__:
             if k not in ('name', '_material', '_structural_params'):
                 v = getattr(self, k)
@@ -247,10 +252,13 @@ class Layer(SMaterial):
         film thickness in angstrom
     """
 
-    _valid_init_kwargs = {'roughness': 'root mean square roughness',
-                          'density': 'density in kg/m^3',
-                          'relaxation': 'degree of relaxation',
-                          'lat_correl': 'lateral correlation length'}
+    _valid_init_kwargs = {
+        'name': 'Custom name of the Layer',
+        'roughness': 'root mean square roughness',
+        'density': 'density in kg/m^3',
+        'relaxation': 'degree of relaxation',
+        'lat_correl': 'lateral correlation length'
+    }
 
     def __init__(self, material, thickness, **kwargs):
         """
@@ -431,13 +439,16 @@ class Powder(SMaterial):
         crystallites.
     """
 
-    _valid_init_kwargs = {'crystallite_size_lor': 'Lorentzian cryst. size',
-                          'crystallite_size_gauss': 'Gaussian cryst. size',
-                          'strain_lor': 'microstrain broadening',
-                          'strain_gauss': 'microstrain broadening',
-                          'preferred_orientation': 'HKL of pref. orientation',
-                          'preferred_orientation_factor':
-                          'March-Dollase preferred orientation factor'}
+    _valid_init_kwargs = {
+        'name': 'Custom name of the Powder',
+        'crystallite_size_lor': 'Lorentzian crystallite size',
+        'crystallite_size_gauss': 'Gaussian crystallite size',
+        'strain_lor': 'microstrain broadening',
+        'strain_gauss': 'microstrain broadening',
+        'preferred_orientation': 'HKL of the preferred orientation',
+        'preferred_orientation_factor':
+        'March-Dollase preferred orientation factor'
+    }
 
     def __init__(self, material, volume, **kwargs):
         """


### PR DESCRIPTION
partly addressing issue #140 

naming of materials for simulations allows to give more meaning full names to repeated materials.
this allows to more intuitively link the parameters of such layers in simulations.

Exemplary use:
```
import xrayutilities as xu
# load materials
GaAs_ = xu.materials.GaAs
AlAs_ = xu.materials.AlAs
AlGaAs80 = xu.materials.AlGaAs(0.20)

# define layers
sub = xu.simpack.Layer(GaAs_, float('inf'))
lay_AlGaAs80 = xu.simpack.Layer(AlGaAs80, 20000, relaxation=0., name="AlGaAs SL")
lay_GaAs = xu.simpack.Layer(GaAs_, 2000, relaxation=0., name="GaAs SL")
cap = xu.simpack.Layer(GaAs_, 3200, relaxation=0.0, name="GaAs cap")

# make superlattice structure
heterostructure = xu.simpack.PseudomorphicStack001(
    'Hetereostructure', sub + (lay_AlGaAs80 + lay_GaAs)*5 + cap)
print(heterostructure)
```

The corresponding output is then

```
Hetereostructure [
  Layer-GaAs (a: 5.6532, at0_Ga_4a_occupation: 1, at1_As_4c_occupation: 1, at0_Ga_4a_biso: 0, at1_As_4c_biso: 0, thickness: inf, ),
  Layer-AlGaAs_SL (a: 5.6532, at0_Al_4a_occupation: 0.8, at1_As_4c_occupation: 1, at2_Ga_4a_occupation: 0.2, at0_Al_4a_biso: 0, at1_As_4c_biso: 0, at2_Ga_4a_biso: 0, relaxation: 0, thickness: 20000, c: 5.6664, ),
  Layer-GaAs_SL (a: 5.6532, at0_Ga_4a_occupation: 1, at1_As_4c_occupation: 1, at0_Ga_4a_biso: 0, at1_As_4c_biso: 0, relaxation: 0, thickness: 2000, ),
  Layer-AlGaAs_SL_1 (a: 5.6532, at0_Al_4a_occupation: 0.8, at1_As_4c_occupation: 1, at2_Ga_4a_occupation: 0.2, at0_Al_4a_biso: 0, at1_As_4c_biso: 0, at2_Ga_4a_biso: 0, relaxation: 0, thickness: 20000, c: 5.6664, ),
  Layer-GaAs_SL_1 (a: 5.6532, at0_Ga_4a_occupation: 1, at1_As_4c_occupation: 1, at0_Ga_4a_biso: 0, at1_As_4c_biso: 0, relaxation: 0, thickness: 2000, ),
  Layer-AlGaAs_SL_2 (a: 5.6532, at0_Al_4a_occupation: 0.8, at1_As_4c_occupation: 1, at2_Ga_4a_occupation: 0.2, at0_Al_4a_biso: 0, at1_As_4c_biso: 0, at2_Ga_4a_biso: 0, relaxation: 0, thickness: 20000, c: 5.6664, ),
  Layer-GaAs_SL_2 (a: 5.6532, at0_Ga_4a_occupation: 1, at1_As_4c_occupation: 1, at0_Ga_4a_biso: 0, at1_As_4c_biso: 0, relaxation: 0, thickness: 2000, ),
  Layer-AlGaAs_SL_3 (a: 5.6532, at0_Al_4a_occupation: 0.8, at1_As_4c_occupation: 1, at2_Ga_4a_occupation: 0.2, at0_Al_4a_biso: 0, at1_As_4c_biso: 0, at2_Ga_4a_biso: 0, relaxation: 0, thickness: 20000, c: 5.6664, ),
  Layer-GaAs_SL_3 (a: 5.6532, at0_Ga_4a_occupation: 1, at1_As_4c_occupation: 1, at0_Ga_4a_biso: 0, at1_As_4c_biso: 0, relaxation: 0, thickness: 2000, ),
  Layer-AlGaAs_SL_4 (a: 5.6532, at0_Al_4a_occupation: 0.8, at1_As_4c_occupation: 1, at2_Ga_4a_occupation: 0.2, at0_Al_4a_biso: 0, at1_As_4c_biso: 0, at2_Ga_4a_biso: 0, relaxation: 0, thickness: 20000, c: 5.6664, ),
  Layer-GaAs_SL_4 (a: 5.6532, at0_Ga_4a_occupation: 1, at1_As_4c_occupation: 1, at0_Ga_4a_biso: 0, at1_As_4c_biso: 0, relaxation: 0, thickness: 2000, ),
  Layer-GaAs_cap (a: 5.6532, at0_Ga_4a_occupation: 1, at1_As_4c_occupation: 1, at0_Ga_4a_biso: 0, at1_As_4c_biso: 0, relaxation: 0, thickness: 3200, )
]
```