### PR TITLE
feat: allow distinct hkl in dynamic diffraction multilayer models

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+* allow different Miller indices for the various layers in a dynamic diffraction calculation
+
 v1.7.7, 2024-04-19
 
 * enable creation of Python 3.12 packages

--- a/examples/simpack_xrd_dyn_AlGaAs.py
+++ b/examples/simpack_xrd_dyn_AlGaAs.py
@@ -151,7 +151,7 @@ fitr = fitmdyn.fit(Int, params, om_off, lmfit_kws=lmfit_kws)
 
 
 # get Al composition for perpendicular lattice parameter
-qz = 2 * np.pi * fitmdyn.lmodel.hkl[2] / fitr.params['AlAs_0_80_GaAs_0_20__c']
+qz = 2 * np.pi * hkl[2] / fitr.params['AlAs_0_80_GaAs_0_20__c']
 x_Al = AlGaAs80.ContentBsym(qz, hkl, np.array([0, 0, 1]), GaAs_.a, 0)
 
 # print fit results

--- a/lib/xrayutilities/simpack/models.py
+++ b/lib/xrayutilities/simpack/models.py
@@ -628,7 +628,8 @@ class SimpleDynamicalCoplanarModel(KinematicalModel):
         prepare dynamical calculation by calculating some helper values
         """
         t = self.exp._transform
-        ql0 = t(self.lstack[0].material.Q(*self.hkl[0]))  # use hkl of substrate
+        # use hkl of substrate
+        ql0 = t(self.lstack[0].material.Q(*self.hkl[0]))
         hx = numpy.sqrt(ql0[0]**2 + ql0[1]**2)
         if geometry == 'lo_hi':
             hx = -hx


### PR DESCRIPTION
In some situations it is appropriate to calculate a dynamic diffraction signal for a multilayer where the substrate and layer have close vicinity for peaks with different hkl. e.g. a hexagonal layer on a cubic 111 substrate.