### PR TITLE
Use numpy>=2 as build dependency only for python>=3.9

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+* Use numpy>=2 as build dependency only for python>=3.9 (#188 by @t20100)
+
 v1.7.8, 2024-06-05
 
 * Numpy-2.0 support for wheels on PyPI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,9 @@ requires = [
     # for PyPI; it is also supported to build against 1.xx still.
     # If you do so, please ensure to include a `numpy<2.0` runtime requirement
     # for those binary packages.
-    "numpy>=2.0.0rc1",
+    "numpy>=2.0.0rc1; python_version >= '3.9'",
+    "numpy; python_version < '3.9'",
+
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
This PR proposes to use [dependency specifiers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/#dependency-specifiers) in the `build-system`'s `requires` to use `numpy>2` only for versions of Python that supports it.

Closes #187