### PR TITLE
fix(DarwinModel): avoid use of deprecated scipy.misc functionality

### DIFF
--- a/.azure/templates/testing_job.yml
+++ b/.azure/templates/testing_job.yml
@@ -39,7 +39,7 @@ jobs:
       pip install -r recommended_requirements.txt
     displayName: Install requirements
   - script: |
-      pip install coverage[toml] pytest pytest-cov pytest-azurepipelines pytest-subtests
+      pip install coverage[toml] numtest pytest pytest-cov pytest-azurepipelines pytest-subtests
     displayName: Install test requirements
   - script: |
       pip install -v .[plot]

--- a/.azure/templates/testing_job.yml
+++ b/.azure/templates/testing_job.yml
@@ -39,7 +39,7 @@ jobs:
       pip install -r recommended_requirements.txt
     displayName: Install requirements
   - script: |
-      pip install coverage[toml] numtest pytest pytest-cov pytest-azurepipelines pytest-subtests
+      pip install coverage[toml] pytest pytest-cov pytest-azurepipelines pytest-subtests
     displayName: Install test requirements
   - script: |
       pip install -v .[plot]

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+* avoid use of scipy.misc package. make xrayutilities work with scipy>=1.15 (#202)
 * fix typo in GetStress method of Material/Crystal.
 * improve wording in Experiment class docstrings (#192)
 * fix typo in cache key of atomic structure factor (#189)

--- a/lib/xrayutilities/math/__init__.py
+++ b/lib/xrayutilities/math/__init__.py
@@ -14,7 +14,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Copyright (C) 2009 Eugen Wintersberger <eugen.wintersberger@desy.de>
-# Copyright (C) 2010-2022 Dominik Kriegner <dominik.kriegner@gmail.com>
+# Copyright (C) 2010-2025 Dominik Kriegner <dominik.kriegner@gmail.com>
 
 from .algebra import solve_quartic
 from .fit import (fit_peak2d, gauss_fit, linregress, multPeakFit, multPeakPlot,
@@ -27,7 +27,7 @@ from .functions import (Debye1, Gauss1d, Gauss1d_der_p, Gauss1d_der_x,
                         PseudoVoigt1dArea, PseudoVoigt1dasym,
                         PseudoVoigt1dasym2, PseudoVoigt2d, TwoGauss2d,
                         heaviside, kill_spike, multPeak1d, multPeak2d, smooth)
-from .misc import center_of_mass, fwhm_exp, gcd
+from .misc import center_of_mass, derivative, fwhm_exp, gcd
 from .transforms import (ArbRotation, AxisToZ, AxisToZ_keepXY,
                          CoordinateTransform, Transform, VecAngle, VecCross,
                          VecDot, VecNorm, VecUnit, XRotation, YRotation,

--- a/lib/xrayutilities/math/misc.py
+++ b/lib/xrayutilities/math/misc.py
@@ -170,7 +170,7 @@ def derivative(func, x0, dx=1.0):
     --------
     >>> def f(x):
     ...     return x**2
-    >>> derivative(f, 3.0):
+    >>> derivative(f, 3.0)
     6.0
     """
     # 3-point central difference weights

--- a/lib/xrayutilities/math/misc.py
+++ b/lib/xrayutilities/math/misc.py
@@ -170,7 +170,7 @@ def derivative(func, x0, dx=1.0):
     --------
     >>> def f(x):
     ...     return x**2
-    >>> derivative(f, 3.0, dx=1e-5):  # doctest: +NUMBER
+    >>> derivative(f, 3.0):
     6.0
     """
     # 3-point central difference weights

--- a/lib/xrayutilities/math/misc.py
+++ b/lib/xrayutilities/math/misc.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 #
-# Copyright (c) 2016-2019, 2023 Dominik Kriegner <dominik.kriegner@gmail.com>
+# Copyright (c) 2016-2025 Dominik Kriegner <dominik.kriegner@gmail.com>
 
 import math
 
@@ -139,3 +139,44 @@ def gcd(lst):
         return numpy.gcd.reduce(lst)
     gcdfunc = numpy.frompyfunc(math.gcd, 2, 1)
     return numpy.ufunc.reduce(gcdfunc, lst)
+
+
+def derivative(func, x0, dx=1.0):
+    """
+    First derivative of a function using a 3-point central difference formula.
+
+    This code is a heavily simplified version of the deprecated
+    scipy.misc.derviative.
+
+    Parameters
+    ----------
+    func : function
+        The function to differentiate.
+    x0 : float
+        The point at which to evaluate the derivative.
+    dx : float, optional
+        The step size for finite differences. Default is 1.0.
+
+    Returns
+    -------
+    float
+        The first derivative of the function at x0.
+
+    Notes
+    -----
+    Uses a 3-point central difference formula for simplicity.
+
+    Examples
+    --------
+    >>> def f(x):
+    ...     return x**2
+    >>> derivative(f, 3.0, dx=1e-5)
+    6.0
+    """
+    # 3-point central difference weights
+    weights = [-1, 0, 1]
+    points = [x0 - dx, x0, x0 + dx]
+
+    # Compute the weighted sum
+    val = sum(w * func(p) for w, p in zip(weights, points))
+    return val / (2 * dx)

--- a/lib/xrayutilities/math/misc.py
+++ b/lib/xrayutilities/math/misc.py
@@ -170,7 +170,7 @@ def derivative(func, x0, dx=1.0):
     --------
     >>> def f(x):
     ...     return x**2
-    >>> derivative(f, 3.0, dx=1e-5)
+    >>> derivative(f, 3.0, dx=1e-5):  # doctest: +NUMBER
     6.0
     """
     # 3-point central difference weights

--- a/lib/xrayutilities/simpack/darwin_theory.py
+++ b/lib/xrayutilities/simpack/darwin_theory.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 #
-# Copyright (c) 2016-2023 Dominik Kriegner <dominik.kriegner@gmail.com>
+# Copyright (c) 2016-2025 Dominik Kriegner <dominik.kriegner@gmail.com>
 import abc
 import collections.abc
 import copy
@@ -21,10 +21,9 @@ import warnings
 
 import numpy
 from scipy.constants import physical_constants
-from scipy.misc import derivative
 
 from .. import materials, utilities
-from ..math import heaviside
+from ..math import derivative, heaviside
 from .models import LayerModel
 
 
@@ -384,7 +383,7 @@ class DarwinModelAlloy(DarwinModel, utilities.ABC):
                             directly!""")
                 while t < T:
                     if 'r' in s:
-                        r = abs(derivative(x, t, dx=1.4, n=1))*s['r']
+                        r = abs(derivative(x, t, dx=1.4))*s['r']
                         dperp, apar = self.get_dperp_apar(x(t), apar, r)
                     else:
                         dperp, apar = self.get_dperp_apar(x(t), s['ai'])

--- a/tests/test_math_peak_fit.py
+++ b/tests/test_math_peak_fit.py
@@ -13,14 +13,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 #
-# Copyright (C) 2016-2020 Dominik Kriegner <dominik.kriegner@gmail.com>
+# Copyright (C) 2016-2025 Dominik Kriegner <dominik.kriegner@gmail.com>
 
 import unittest
 
 import numpy
 import xrayutilities as xu
 
-digits = 9
+digits = 7
 
 
 class TestPeakFit(unittest.TestCase):


### PR DESCRIPTION
since I want to avoid added a new dependency (which would not be very well supported by various distribution channels) I decided to reimplement this functionality in xrayutilities

closes #202 

release should be made soon after this is merged