### PR TITLE
build(mesonpy): clean up meson.build file

### DIFF
--- a/.azure/templates/testing_job.yml
+++ b/.azure/templates/testing_job.yml
@@ -46,23 +46,31 @@ jobs:
         displayName: Install test requirements
       - script: |
           pip install -v ".[plot]"
-        condition: ne(variables['Agent.OS'], 'Darwin')
-        displayName: Install xrayutilities
+        displayName: "Install xrayutilities"
+        condition: eq(variables['Agent.OS'], 'Linux')
       - script: |
-          pip install -v --config-settings=setup-args="-Denable_openmp=false" ".[plot]"
+          pip install -v --config-settings=setup-args="--vsenv" ".[plot]"
+        condition: eq(variables['Agent.OS'], 'Windows_NT')
+        displayName: "Install xrayutilities with MSVC (Windows)"
+      - script: |
+          pip install -v --config-settings=setup-args="-Duse_openmp=auto" ".[plot]"
         condition: eq(variables['Agent.OS'], 'Darwin')
-        displayName: "Install xrayutilities without OpenMP"
+        displayName: "Install xrayutilities with optional OpenMP (MacOS)"
       - script: |
           pytest --junitxml=junit/test-results.xml --cov --cov-config pyproject.toml --cov-report=xml --doctest-glob="*.rst"
         displayName: Run pytest
       - script: |
-          pip install --no-build-isolation --config-settings=setup-args="-Denable_openmp=false" --editable .
+          pip install --no-build-isolation --editable .
+        condition: eq(variables['Agent.OS'], 'Linux')
+        displayName: Perform editable installation
+      - script: |
+          pip install --no-build-isolation --config-settings=setup-args="--vsenv" --editable .
+        condition: eq(variables['Agent.OS'], 'Windows_NT')
+        displayName: Perform editable installation (Windows)
+      - script: |
+          pip install --no-build-isolation --config-settings=setup-args="-Duse_openmp=auto" --editable .
         condition: eq(variables['Agent.OS'], 'Darwin')
         displayName: Perform editable installation (MacOS)
-      - script: |
-          pip install --no-build-isolation --editable .
-        condition: ne(variables['Agent.OS'], 'Darwin')
-        displayName: Perform editable installation
       - script: |
           pytest --junitxml=junit/test-results.xml --cov --cov-append --cov-config pyproject.toml --cov-report=xml --doctest-modules  --ignore=lib/xrayutilities/materials/_create_database.py lib
         displayName: Run doctest modules

--- a/README.md
+++ b/README.md
@@ -46,11 +46,6 @@ Using the python package manager pip you can install xrayutilities by executing
 
     pip install xrayutilities
 
-or for a user installation (without admin access) use
-
-    pip install --user xrayutilities
-
-
 Installation (source)
 =====================
 Installing xrayutilities from source is an easy process done by executing
@@ -61,7 +56,11 @@ By default the installation procedure enables OpenMP support (recommended).
 It fails if no OpenMP support is available. It can be disabled by using the
 the following custom meson option for the installation:
 
-    pip install . --config-settings=setup-args="-Denable_openmp=false"
+    pip install . --config-settings=setup-args="-Duse_openmp=disabled"
+
+To allow to proceed with the installation without OpenMP but use it if available use:
+
+    pip install . --config-settings=setup-args="-Duse_openmp=auto"
 
 Requirements
 ------------

--- a/meson.build
+++ b/meson.build
@@ -1,23 +1,12 @@
-project('xrayutilities', 'c',
-  version : run_command('python', '-c',
-    '''
-    try:
-        import tomllib
-    except ImportError:
-        import tomli as tomllib
-    with open("pyproject.toml", "rb") as f:
-        print(tomllib.load(f)["project"]["version"])
-    '''
-  ).stdout().strip()
-)
+project('xrayutilities', 'c', version : '1.7.10')
 
-enable_openmp = get_option('enable_openmp')
+use_openmp = get_option('use_openmp')
 
 # Fetch the C compiler
 cc = meson.get_compiler('c')
 
 # Import Python module
-pyx = import('python').find_installation()
+pyx = import('python').find_installation(pure: false)
 
 # Fetch Numpy include directory
 numpy_include = run_command(pyx, '-c', 'import numpy; print(numpy.get_include())', check: true).stdout().strip()
@@ -26,25 +15,7 @@ numpy_include = run_command(pyx, '-c', 'import numpy; print(numpy.get_include())
 include_dirs = include_directories('src', numpy_include)
 
 # Find OpenMP dependency
-openmp_dep = dependency('openmp', required : enable_openmp)
-
-# Handle OpenMP support based on the option and dependency status
-if enable_openmp
-  if not openmp_dep.found()
-    error('OpenMP was explicitly enabled but could not be found on this system.')
-  else
-    message('OpenMP support enabled')
-    # Add compiler-specific OpenMP flags
-    if cc.get_id() == 'gcc' or cc.get_id() == 'clang' or cc.get_id() == 'mingw'
-      add_project_arguments('-fopenmp', language: 'c')
-      add_project_link_arguments('-lgomp', language: 'c')
-    elif cc.get_id() == 'msvc'
-      add_project_arguments('/openmp', language: 'c')
-    endif
-  endif
-else
-  message('OpenMP support disabled')
-endif
+openmp_dep = dependency('openmp', required : use_openmp)
 
 # Add the Python extension module
 pyx.extension_module(
@@ -62,7 +33,8 @@ pyx.extension_module(
   ),
   include_directories : include_dirs,
   install: true,
-  install_dir: join_paths(pyx.get_install_dir(), 'xrayutilities'),
+  subdir: 'xrayutilities',
+  dependencies: openmp_dep,
 )
 
 # Install the Python extension

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,1 @@
-option('enable_openmp', type: 'boolean', value: true, description: 'Enable OpenMP support')
+option('use_openmp', type: 'feature', value: 'enabled', description: 'Use OpenMP support')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,11 @@ requires = [
     # for those binary packages.
     "numpy>=2.0.0rc1; python_version >= '3.9'",
     "numpy; python_version < '3.9'",
-    # tomli needed by meson.build to load version variable
-    "tomli >= 2.0.1 ; python_version < '3.11'",
 ]
 build-backend = "mesonpy"
 
 [project]
 name = "xrayutilities"
-version = "1.7.10"
 description = "Package for x-ray diffraction data evaluation"
 readme = "README.md"
 license = { text = "GPL-2.0-or-later" }
@@ -42,14 +39,12 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
 ]
 requires-python = ">=3.7,<4.0"
+dynamic = ["version"]
 dependencies = ["numpy>=1.9.2", "scipy>=0.18.0", "h5py", "lmfit>=1.0.1"]
 
 [project.optional-dependencies]
 plot = ["matplotlib>=3.1.0"]
 3D = ["mayavi"]
-
-[tool.meson-python.args]
-setup = ['--vsenv']
 
 [project.urls]
 homepage = "https://xrayutilities.sourceforge.io"

--- a/release.txt
+++ b/release.txt
@@ -8,8 +8,8 @@ CHECK EVERYTHING
 
 Is everything running fine? perform the tests and run the examples
 
-  # change the version in lib/xrayutilties/VERSION
-  # update copyright notice in doc/source/conf.py and README.md
+  # change the version in meson.build
+  # update copyright notice in README.md
   pycodestyle lib
   # allowed output is:
 lib/xrayutilities/materials/elements.py:36:1: E741 ambiguous variable name 'O'


### PR DESCRIPTION
Following hints in the comments to #206 by @eli-schwartz the build system is cleaned up significantly and features of meson-python are used more effectively.

The version number is now included in meson.build as a single source of truth. This will currently not yet work with the cibuildwheel pipeline which should be addressed separately. Likely one needs a way to add a revision number for the builds