### PR TITLE
fix(c-code): fix small memory leak, cleanup improvements

### DIFF
--- a/.azure/azure-buildwheels.yml
+++ b/.azure/azure-buildwheels.yml
@@ -94,7 +94,7 @@ jobs:
           $VERSION = git describe --tags --always | ForEach-Object { $_ -replace '^v' }
           meson rewrite kwargs set project / version "$VERSION"
           Write-Host "meson.build updated to version: $VERSION"
-        condition: and(not(startsWith(variables['build.sourceBranch'], 'refs/tags/'))
+        condition: not(startsWith(variables['build.sourceBranch'], 'refs/tags/'))
         displayName: Set version from Git
       - bash: cibuildwheel --output-dir wheelhouse .
         displayName: Build wheels

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+* fix a memory leak in the c-code (not freed memory of function pointers)
+* improved error checking and clean up in c-code
 * convert to meson-python bases build system
 
 v1.7.10, 2025-01-17

--- a/lib/xrayutilities/experiment.py
+++ b/lib/xrayutilities/experiment.py
@@ -14,7 +14,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Copyright (C) 2009-2010 Eugen Wintersberger <eugen.wintersberger@desy.de>
-# Copyright (c) 2009-2023 Dominik Kriegner <dominik.kriegner@gmail.com>
+# Copyright (c) 2009-2025 Dominik Kriegner <dominik.kriegner@gmail.com>
 # Copyright (C) 2012 Tanja Etzelstorfer <tanja.etzelstorfer@jku.at>
 
 """
@@ -472,7 +472,8 @@ class QConversion:
 
         UB = numpy.asarray(kwargs.get('UB', self.UB))
 
-        sd = numpy.asarray(kwargs.get('sampledis', [0, 0, 0]))
+        sd = numpy.asarray(kwargs.get('sampledis', [0, 0, 0]),
+                           dtype=numpy.double)
         if 'sampledis' in kwargs:
             flags |= QConvFlags.HAS_SAMPLEDIS
 

--- a/lib/xrayutilities/gridder.py
+++ b/lib/xrayutilities/gridder.py
@@ -170,8 +170,8 @@ class Gridder(utilities.ABC):
         prepare array for passing to c-code
         """
         if isinstance(a, (list, tuple, float, int)):
-            a = numpy.asarray(a, dtype=numpy.double)
-        return a.reshape(a.size)
+            a = numpy.asarray(a)
+        return a.reshape(a.size).astype(numpy.double)
 
     def Clear(self):
         """

--- a/lib/xrayutilities/gridder.py
+++ b/lib/xrayutilities/gridder.py
@@ -44,7 +44,8 @@ def delta(min_value, max_value, n):
    n :	 number of steps
     """
     if n != 1:
-        return (float(max_value) - float(min_value)) / float(n - 1)
+        return (numpy.double(max_value) - numpy.double(min_value)) / \
+               numpy.double(n - 1)
     return numpy.inf
 
 
@@ -64,7 +65,7 @@ def axis(min_value, max_value, n):
 
     if n != 1:
         d = delta(min_value, max_value, n)
-        a = min_value + d * numpy.arange(0, n)
+        a = min_value + d * numpy.arange(0, n, dtype=numpy.double)
     else:
         a = (min_value + max_value) / 2.
 
@@ -169,7 +170,7 @@ class Gridder(utilities.ABC):
         prepare array for passing to c-code
         """
         if isinstance(a, (list, tuple, float, int)):
-            a = numpy.asarray(a)
+            a = numpy.asarray(a, dtype=numpy.double)
         return a.reshape(a.size)
 
     def Clear(self):

--- a/meson.build
+++ b/meson.build
@@ -51,6 +51,7 @@ pyx.extension_module(
   'cxrayutilities',  # Python extension name
   sources : files(
     'src/cxrayutilities.c',
+    'src/array_utils.c',
     'src/block_average.c',
     'src/file_io.c',
     'src/gridder1d.c',

--- a/src/array_utils.c
+++ b/src/array_utils.c
@@ -19,61 +19,6 @@
 
 #include "array_utils.h"
 
-int check_array(PyArrayObject** arr_ptr, int ndims, int typenum, const char* arr_name) {
-    if (!arr_ptr || !*arr_ptr) {
-        PyErr_Format(PyExc_ValueError, "Array pointer for '%s' is NULL", arr_name);
-        return 0; // Indicate failure
-    }
-
-    PyArrayObject* arr = *arr_ptr;
-
-    if (!PyArray_Check(arr)) {
-        PyErr_Format(PyExc_TypeError, "Object '%s' is not an array", arr_name);
-        return 0;
-    }
-
-    if (PyArray_NDIM(arr) != ndims) {
-        PyErr_Format(PyExc_ValueError, "Array '%s' must have %d dimension(s), but has %d", arr_name, ndims, PyArray_NDIM(arr));
-        return 0;
-    }
-
-    if (PyArray_TYPE(arr) != typenum) {
-        PyArray_Descr *expected_descr = PyArray_DescrFromType(typenum);
-        PyArray_Descr *actual_descr = PyArray_DESCR(arr);
-
-        const char *expected_name = "unknown";
-        const char *actual_name = "unknown";
-
-        if (expected_descr && expected_descr->typeobj) {
-            expected_name = expected_descr->typeobj->tp_name;
-        }
-        if (actual_descr && actual_descr->typeobj) {
-            actual_name = actual_descr->typeobj->tp_name;
-        }
-
-        PyErr_Format(PyExc_ValueError, "Array '%s' must be of type %s, but is %s",
-                     arr_name, expected_name, actual_name);
-
-        Py_XDECREF(expected_descr); // Important: Decref the descriptor
-        return 0;
-    }
-
-    if (!PyArray_ISCARRAY(arr)) {
-        PyArrayObject* tmp = PyArray_GETCONTIGUOUS(arr);
-        if (tmp == NULL) {
-            PyErr_Format(PyExc_RuntimeError, "Could not create contiguous array for '%s'", arr_name);
-            return 0;
-        } else {
-            Py_DECREF(*arr_ptr); // Decrement original
-            *arr_ptr = tmp;      // Assign new one
-            return 1; // Indicate that a new array was created
-        }
-    } else {
-        Py_INCREF(arr); // Increment refcount of the array
-        return 1; // Indicate that a new array was NOT created, but refcount was incremented
-    }
-}
-
 PyArrayObject* check_and_convert_to_contiguous(PyObject* obj, int ndims, int typenum, const char* name) {
     if (!PyArray_Check(obj)) {
         PyErr_Format(PyExc_TypeError, "Object '%s' is not an array", name);

--- a/src/array_utils.c
+++ b/src/array_utils.c
@@ -1,0 +1,102 @@
+/*
+ * This file is part of xrayutilities.
+ *
+ * xrayutilities is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright (C) 2025 Dominik Kriegner <dominik.kriegner@gmail.com>
+*/
+
+#include "array_utils.h"
+
+int check_array(PyArrayObject** arr_ptr, int ndims, int typenum, const char* arr_name) {
+    if (!arr_ptr || !*arr_ptr) {
+        PyErr_Format(PyExc_ValueError, "Array pointer for '%s' is NULL", arr_name);
+        return 0; // Indicate failure
+    }
+
+    PyArrayObject* arr = *arr_ptr;
+
+    if (!PyArray_Check(arr)) {
+        PyErr_Format(PyExc_TypeError, "Object '%s' is not an array", arr_name);
+        return 0;
+    }
+
+    if (PyArray_NDIM(arr) != ndims) {
+        PyErr_Format(PyExc_ValueError, "Array '%s' must have %d dimension(s), but has %d", arr_name, ndims, PyArray_NDIM(arr));
+        return 0;
+    }
+
+    if (PyArray_TYPE(arr) != typenum) {
+        PyArray_Descr *expected_descr = PyArray_DescrFromType(typenum);
+        PyArray_Descr *actual_descr = PyArray_DESCR(arr);
+
+        const char *expected_name = "unknown";
+        const char *actual_name = "unknown";
+
+        if (expected_descr && expected_descr->typeobj) {
+            expected_name = expected_descr->typeobj->tp_name;
+        }
+        if (actual_descr && actual_descr->typeobj) {
+            actual_name = actual_descr->typeobj->tp_name;
+        }
+
+        PyErr_Format(PyExc_ValueError, "Array '%s' must be of type %s, but is %s",
+                     arr_name, expected_name, actual_name);
+
+        Py_XDECREF(expected_descr); // Important: Decref the descriptor
+        return 0;
+    }
+
+    if (!PyArray_ISCARRAY(arr)) {
+        PyArrayObject* tmp = PyArray_GETCONTIGUOUS(arr);
+        if (tmp == NULL) {
+            PyErr_Format(PyExc_RuntimeError, "Could not create contiguous array for '%s'", arr_name);
+            return 0;
+        } else {
+            Py_DECREF(*arr_ptr); // Decrement original
+            *arr_ptr = tmp;      // Assign new one
+            return 1; // Indicate that a new array was created
+        }
+    } else {
+        Py_INCREF(arr); // Increment refcount of the array
+        return 1; // Indicate that a new array was NOT created, but refcount was incremented
+    }
+}
+
+PyArrayObject* check_and_convert_to_contiguous(PyObject* obj, int ndims, int typenum, const char* name) {
+    if (!PyArray_Check(obj)) {
+        PyErr_Format(PyExc_TypeError, "Object '%s' is not an array", name);
+        return NULL;
+    }
+
+    PyArrayObject* arr = (PyArrayObject*)obj;
+
+    if (PyArray_NDIM(arr) != ndims) {
+        PyErr_Format(PyExc_ValueError, "Array '%s' must have %d dimension(s), but has %d", name, ndims, PyArray_NDIM(arr));
+        return NULL;
+    }
+
+    if (PyArray_TYPE(arr) != typenum) {
+        PyErr_Format(PyExc_ValueError, "Array '%s' must be of type %s, but is %s",
+                     name, PyArray_DescrFromType(typenum)->typeobj->tp_name, PyArray_DESCR(arr)->typeobj->tp_name);
+        return NULL;
+    }
+
+    if (PyArray_ISCARRAY(arr)) {
+        Py_INCREF(arr); // Increment refcount if already contiguous
+        return arr;
+    } else {
+        return PyArray_GETCONTIGUOUS(arr);
+    }
+}

--- a/src/array_utils.h
+++ b/src/array_utils.h
@@ -31,5 +31,4 @@
     #define NPY_ARRAY_C_CONTIGUOUS  NPY_C_CONTIGUOUS
 #endif
 
-int check_array(PyArrayObject** arr_ptr, int ndims, int typenum, const char* arr_name);
 PyArrayObject* check_and_convert_to_contiguous(PyObject* obj, int ndims, int typenum, const char* name);

--- a/src/array_utils.h
+++ b/src/array_utils.h
@@ -1,0 +1,35 @@
+/*
+ * This file is part of xrayutilities.
+ *
+ * xrayutilities is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright (C) 2025 Dominik Kriegner <dominik.kriegner@gmail.com>
+*/
+
+#include <Python.h>
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#define PY_ARRAY_UNIQUE_SYMBOL XU_UNIQUE_SYMBOL
+#define NO_IMPORT_ARRAY
+#include <numpy/arrayobject.h>
+
+/*
+ * set numpy API specific macros
+ */
+#if NPY_FEATURE_VERSION < 0x00000007
+    #define NPY_ARRAY_ALIGNED       NPY_ALIGNED
+    #define NPY_ARRAY_C_CONTIGUOUS  NPY_C_CONTIGUOUS
+#endif
+
+int check_array(PyArrayObject** arr_ptr, int ndims, int typenum, const char* arr_name);
+PyArrayObject* check_and_convert_to_contiguous(PyObject* obj, int ndims, int typenum, const char* name);

--- a/src/block_average.c
+++ b/src/block_average.c
@@ -118,13 +118,13 @@ PyObject* block_average2d(PyObject *self, PyObject *args) {
     outarr = (PyArrayObject *) PyArray_SimpleNew(2, nout, NPY_DOUBLE);
     cout = (double *) PyArray_DATA(outarr);
 
-    #ifdef __OPENMP__
+#ifdef __OPENMP__
     /* set openmp thread numbers dynamically */
     OMPSETNUMTHREADS(nthreads);
-    #endif
 
     #pragma omp parallel for default(shared) \
      private(i, j, k, l, buf) schedule(static)
+#endif
     for (i = 0; i < Nch2; i = i + Nav2) {
         for (j = 0; j < Nch1; j = j + Nav1) {
             buf = 0.;
@@ -183,14 +183,14 @@ PyObject* block_average_PSD(PyObject *self, PyObject *args) {
     outarr = (PyArrayObject *) PyArray_SimpleNew(2, nout, NPY_DOUBLE);
     cout = (double *) PyArray_DATA(outarr);
 
-    #ifdef __OPENMP__
+#ifdef __OPENMP__
     /* set openmp thread numbers dynamically */
     OMPSETNUMTHREADS(nthreads);
-    #endif
 
     /* c-code following is performing the block averaging */
     #pragma omp parallel for default(shared) private(i, j, k, buf) \
      schedule(static)
+#endif
     for (i = 0; i < Nspec; ++i) {
         for (j = 0; j < Nch; j = j + Nav) {
             buf = 0;
@@ -258,13 +258,13 @@ PyObject* block_average_CCD(PyObject *self, PyObject *args) {
     outarr = (PyArrayObject *) PyArray_SimpleNew(3, nout, NPY_DOUBLE);
     cout = (double *) PyArray_DATA(outarr);
 
-    #ifdef __OPENMP__
+#ifdef __OPENMP__
     /* set openmp thread numbers dynamically */
     OMPSETNUMTHREADS(nthreads);
-    #endif
 
     #pragma omp parallel for default(shared) \
      private(i, j, k, l, n, buf) schedule(static)
+#endif
     for (n = 0; n < Nframes; n++) {
         for (i = 0; i < Nch2; i = i + Nav2) {
             for (j = 0; j < Nch1; j = j + Nav1) {

--- a/src/gridder3d.c
+++ b/src/gridder3d.c
@@ -15,7 +15,7 @@
  * along with this program; if not, see <http://www.gnu.org/licenses/>.
  *
  * Copyright (C) 2013 Eugen Wintersberger <eugen.wintersberger@desy.de>
- * Copyright (C) 2013, 2015 Dominik Kriegner <dominik.kriegner@gmail.com>
+ * Copyright (C) 2013-2025 Dominik Kriegner <dominik.kriegner@gmail.com>
  *
  ******************************************************************************
  *
@@ -26,73 +26,84 @@
 #include "gridder.h"
 #include "gridder_utils.h"
 
-PyObject* pyfuzzygridder3d(PyObject *self, PyObject *args)
-{
-    PyArrayObject *py_x = NULL, *py_y = NULL, *py_z = NULL, *py_data = NULL,
-                  *py_output = NULL, *py_norm = NULL;
+#include <Python.h>
+#include <numpy/arrayobject.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
 
-    double *x = NULL, *y = NULL, *z = NULL, *data = NULL, *odata = NULL,
-           *norm = NULL;
+// ... (check_and_convert_to_contiguous function - same as before)
+
+PyObject* pyfuzzygridder3d(PyObject *self, PyObject *args) {
+    PyArrayObject *px = NULL, *py = NULL, *pz = NULL, *pdata = NULL, *poutput = NULL, *pnorm = NULL;
+    double *x = NULL, *y = NULL, *z = NULL, *data = NULL, *odata = NULL, *norm = NULL;
     double xmin, xmax, ymin, ymax, zmin, zmax, wx, wy, wz;
     unsigned int nx, ny, nz;
     int flags;
     int n, result;
+    PyObject *return_value = NULL;
+
+    PyObject *xobj = NULL, *yobj = NULL, *zobj = NULL, *dataobj = NULL, *outputobj = NULL, *normobj = NULL;
 
     if (!PyArg_ParseTuple(args, "O!O!O!O!IIIddddddO!|O!dddi",
-                         &PyArray_Type, &py_x,
-                         &PyArray_Type, &py_y,
-                         &PyArray_Type, &py_z,
-                         &PyArray_Type, &py_data,
+                         &PyArray_Type, &xobj,
+                         &PyArray_Type, &yobj,
+                         &PyArray_Type, &zobj,
+                         &PyArray_Type, &dataobj,
                          &nx, &ny, &nz,
                          &xmin, &xmax, &ymin, &ymax, &zmin, &zmax,
-                         &PyArray_Type, &py_output,
-                         &PyArray_Type, &py_norm,
+                         &PyArray_Type, &outputobj,
+                         &PyArray_Type, &normobj,
                          &wx, &wy, &wz, &flags)) {
         return NULL;
     }
 
-    /* check input variables */
-    PYARRAY_CHECK(py_x, 1, NPY_DOUBLE, "x-axis must be a 1D double array!");
-    PYARRAY_CHECK(py_y, 1, NPY_DOUBLE, "y-axis must be a 1D double array!");
-    PYARRAY_CHECK(py_z, 1, NPY_DOUBLE, "z-axis must be a 1D double array!");
-    PYARRAY_CHECK(py_data, 1, NPY_DOUBLE,
-                  "input data must be a 1D double array!");
-    PYARRAY_CHECK(py_output, 3, NPY_DOUBLE,
-                  "ouput data must be a 2D double array!");
-    if (py_norm != NULL) {
-        PYARRAY_CHECK(py_norm, 3, NPY_DOUBLE,
-                      "norm data must be a 2D double array!");
+    px = check_and_convert_to_contiguous(xobj, 1, NPY_DOUBLE, "x-axis");
+    if (!px) goto cleanup;
+
+    py = check_and_convert_to_contiguous(yobj, 1, NPY_DOUBLE, "y-axis");
+    if (!py) goto cleanup;
+
+    pz = check_and_convert_to_contiguous(zobj, 1, NPY_DOUBLE, "z-axis");
+    if (!pz) goto cleanup;
+
+    pdata = check_and_convert_to_contiguous(dataobj, 1, NPY_DOUBLE, "input data");
+    if (!pdata) goto cleanup;
+
+    poutput = check_and_convert_to_contiguous(outputobj, 3, NPY_DOUBLE, "output data");
+    if (!poutput) goto cleanup;
+
+    if (normobj != NULL) {
+        pnorm = check_and_convert_to_contiguous(normobj, 3, NPY_DOUBLE, "norm");
+        if (!pnorm) goto cleanup;
     }
 
-    /* get data */
-    x = (double *) PyArray_DATA(py_x);
-    y = (double *) PyArray_DATA(py_y);
-    z = (double *) PyArray_DATA(py_z);
-    data = (double *) PyArray_DATA(py_data);
-    odata = (double *) PyArray_DATA(py_output);
-    if (py_norm != NULL) {
-        norm = (double *) PyArray_DATA(py_norm);
+    x = (double *)PyArray_DATA(px);
+    y = (double *)PyArray_DATA(py);
+    z = (double *)PyArray_DATA(pz);
+    data = (double *)PyArray_DATA(pdata);
+    odata = (double *)PyArray_DATA(poutput);
+    if (pnorm != NULL) {
+        norm = (double *)PyArray_DATA(pnorm);
     }
 
-    /* get the total number of points */
-    n = (int) PyArray_SIZE(py_x);
+    n = (int)PyArray_SIZE(px);
 
-    /* call the actual gridder routine */
     result = fuzzygridder3d(x, y, z, data, n, nx, ny, nz,
-                            xmin, xmax, ymin, ymax, zmin, zmax, odata, norm,
-                            wx, wy, wz, flags);
+                           xmin, xmax, ymin, ymax, zmin, zmax, odata, norm,
+                           wx, wy, wz, flags);
 
-    /* clean up */
-    Py_DECREF(py_x);
-    Py_DECREF(py_y);
-    Py_DECREF(py_z);
-    Py_DECREF(py_data);
-    Py_DECREF(py_output);
-    if (py_norm != NULL) {
-        Py_DECREF(py_norm);
-    }
+    return_value = Py_BuildValue("i", result);
 
-    return Py_BuildValue("i", &result);
+cleanup:
+    Py_XDECREF(pnorm);
+    Py_XDECREF(poutput);
+    Py_XDECREF(pdata);
+    Py_XDECREF(pz);
+    Py_XDECREF(py);
+    Py_XDECREF(px);
+
+    return return_value;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -274,70 +285,74 @@ int fuzzygridder3d(double *x, double *y, double *z, double *data,
 /*---------------------------------------------------------------------------*/
 PyObject* pygridder3d(PyObject *self, PyObject *args)
 {
-    PyArrayObject *py_x = NULL, *py_y = NULL, *py_z = NULL, *py_data = NULL,
-                  *py_output = NULL, *py_norm = NULL;
-
-    double *x = NULL, *y = NULL, *z = NULL, *data = NULL, *odata = NULL,
-           *norm = NULL;
+    PyArrayObject *px = NULL, *py = NULL, *pz = NULL, *pdata = NULL, *poutput = NULL, *pnorm = NULL;
+    double *x = NULL, *y = NULL, *z = NULL, *data = NULL, *odata = NULL, *norm = NULL;
     double xmin, xmax, ymin, ymax, zmin, zmax;
     unsigned int nx, ny, nz;
     int flags;
     int n, result;
+    PyObject *return_value = NULL;
+
+    PyObject *xobj = NULL, *yobj = NULL, *zobj = NULL, *dataobj = NULL, *outputobj = NULL, *normobj = NULL;
 
     if (!PyArg_ParseTuple(args, "O!O!O!O!IIIddddddO!|O!i",
-                         &PyArray_Type, &py_x,
-                         &PyArray_Type, &py_y,
-                         &PyArray_Type, &py_z,
-                         &PyArray_Type, &py_data,
+                         &PyArray_Type, &xobj,
+                         &PyArray_Type, &yobj,
+                         &PyArray_Type, &zobj,
+                         &PyArray_Type, &dataobj,
                          &nx, &ny, &nz,
                          &xmin, &xmax, &ymin, &ymax, &zmin, &zmax,
-                         &PyArray_Type, &py_output,
-                         &PyArray_Type, &py_norm,
+                         &PyArray_Type, &outputobj,
+                         &PyArray_Type, &normobj,
                          &flags)) {
         return NULL;
     }
 
-    /* check input variables */
-    PYARRAY_CHECK(py_x, 1, NPY_DOUBLE, "x-axis must be a 1D double array!");
-    PYARRAY_CHECK(py_y, 1, NPY_DOUBLE, "y-axis must be a 1D double array!");
-    PYARRAY_CHECK(py_z, 1, NPY_DOUBLE, "z-axis must be a 1D double array!");
-    PYARRAY_CHECK(py_data, 1, NPY_DOUBLE,
-                  "input data must be a 1D double array!");
-    PYARRAY_CHECK(py_output, 3, NPY_DOUBLE,
-                  "ouput data must be a 2D double array!");
-    if (py_norm != NULL) {
-        PYARRAY_CHECK(py_norm, 3, NPY_DOUBLE,
-                      "norm data must be a 2D double array!");
+    px = check_and_convert_to_contiguous(xobj, 1, NPY_DOUBLE, "x-axis");
+    if (!px) goto cleanup;
+
+    py = check_and_convert_to_contiguous(yobj, 1, NPY_DOUBLE, "y-axis");
+    if (!py) goto cleanup;
+
+    pz = check_and_convert_to_contiguous(zobj, 1, NPY_DOUBLE, "z-axis");
+    if (!pz) goto cleanup;
+
+    pdata = check_and_convert_to_contiguous(dataobj, 1, NPY_DOUBLE, "input data");
+    if (!pdata) goto cleanup;
+
+    poutput = check_and_convert_to_contiguous(outputobj, 3, NPY_DOUBLE, "output data");
+    if (!poutput) goto cleanup;
+
+    if (normobj != NULL) {
+        pnorm = check_and_convert_to_contiguous(normobj, 3, NPY_DOUBLE, "norm");
+        if (!pnorm) goto cleanup;
     }
 
-    /* get data */
-    x = (double *) PyArray_DATA(py_x);
-    y = (double *) PyArray_DATA(py_y);
-    z = (double *) PyArray_DATA(py_z);
-    data = (double *) PyArray_DATA(py_data);
-    odata = (double *) PyArray_DATA(py_output);
-    if (py_norm != NULL) {
-        norm = (double *) PyArray_DATA(py_norm);
+    x = (double *)PyArray_DATA(px);
+    y = (double *)PyArray_DATA(py);
+    z = (double *)PyArray_DATA(pz);
+    data = (double *)PyArray_DATA(pdata);
+    odata = (double *)PyArray_DATA(poutput);
+    if (pnorm != NULL) {
+        norm = (double *)PyArray_DATA(pnorm);
     }
 
-    /* get the total number of points */
-    n = (int) PyArray_SIZE(py_x);
+    n = (int)PyArray_SIZE(px);
 
-    /* call the actual gridder routine */
     result = gridder3d(x, y, z, data, n, nx, ny, nz,
-                       xmin, xmax, ymin, ymax, zmin, zmax, odata, norm, flags);
+                      xmin, xmax, ymin, ymax, zmin, zmax, odata, norm, flags);
 
-    /* clean up */
-    Py_DECREF(py_x);
-    Py_DECREF(py_y);
-    Py_DECREF(py_z);
-    Py_DECREF(py_data);
-    Py_DECREF(py_output);
-    if (py_norm != NULL) {
-        Py_DECREF(py_norm);
-    }
+    return_value = Py_BuildValue("i", result);
 
-    return Py_BuildValue("i", &result);
+cleanup:
+    Py_XDECREF(pnorm);
+    Py_XDECREF(poutput);
+    Py_XDECREF(pdata);
+    Py_XDECREF(pz);
+    Py_XDECREF(py);
+    Py_XDECREF(px);
+
+    return return_value;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -436,4 +451,3 @@ int gridder3d(double *x, double *y, double *z, double *data, unsigned int n,
 
     return 0;
 }
-

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,5 +1,6 @@
 # src/meson.build
 sources = files(
+  'array_utils.c',
   'block_average.c',
   'cxrayutilities.c',
   'file_io.c',
@@ -12,6 +13,7 @@ sources = files(
 )
 
 headers = files(
+  'array_utils.h',
   'gridder.h',
   'gridder_utils.h',
   'qconversion.h',

--- a/src/qconversion.c
+++ b/src/qconversion.c
@@ -852,9 +852,11 @@ int ang2q_conversion(double *sampleAngles, double *detectorAngles,
     normalize(local_ri);
 
     /* calculate rotation matices and perform rotations */
+#ifdef __OPENMP__
     #pragma omp parallel for default(shared) \
             private(i, j, ki, mtemp, mtemp2, ms, md) \
             schedule(static)
+#endif
     for (i = 0; i < Npoints; ++i) {
         /* determine sample rotations */
         ident(mtemp);
@@ -947,9 +949,11 @@ int ang2q_conversion_sd(
     normalize(local_ri);
 
     /* calculate rotation matices and perform rotations */
+#ifdef __OPENMP__
     #pragma omp parallel for default(shared) \
             private(i, j, mtemp, mtemp2, ms, md) \
             schedule(static)
+#endif
     for (i = 0; i < Npoints; ++i) {
         /* determine sample rotations */
         ident(mtemp);
@@ -1041,9 +1045,11 @@ int ang2q_conversion_trans(
     normalize(local_ri);
 
     /* calculate rotation matices and perform rotations */
+#ifdef __OPENMP__
     #pragma omp parallel for default(shared) \
             private(i, j, mtemp, mtemp2, ms, rd) \
             schedule(static)
+#endif
     for (i = 0; i < Npoints; ++i) {
         /* determine sample rotations */
         ident(mtemp);
@@ -1134,9 +1140,11 @@ int ang2q_conversion_sdtrans(
     normalize(local_ri);
 
     /* calculate rotation matices and perform rotations */
+#ifdef __OPENMP__
     #pragma omp parallel for default(shared) \
             private(i, j, mtemp, mtemp2, ms, rd) \
             schedule(static)
+#endif
     for (i = 0; i < Npoints; ++i) {
         /* determine sample rotations */
         ident(mtemp);
@@ -1437,9 +1445,11 @@ int ang2q_conversion_linear(
     }
 
     /* calculate rotation matices and perform rotations */
+#ifdef __OPENMP__
     #pragma omp parallel for default(shared) \
             private(i, j, k, f, mtemp, mtemp2, ms, md, rd, rtemp) \
             schedule(static)
+#endif
     for (i = 0; i < Npoints; ++i) {
         /* length of k */
         f = M_2PI / lambda[i];
@@ -1554,9 +1564,11 @@ int ang2q_conversion_linear_sd(
     }
 
     /* calculate rotation matices and perform rotations */
+#ifdef __OPENMP__
     #pragma omp parallel for default(shared) \
             private(i, j, k, f, mtemp, mtemp2, ms, md, rd, rtemp) \
             schedule(static)
+#endif
     for (i = 0; i < Npoints; ++i) {
         /* length of k */
         f = M_2PI / lambda[i];
@@ -1672,9 +1684,11 @@ int ang2q_conversion_linear_trans(
     }
 
     /* calculate rotation matices and perform rotations */
+#ifdef __OPENMP__
     #pragma omp parallel for default(shared) \
             private(i, j, k, f, mtemp, mtemp2, ms, rd) \
             schedule(static)
+#endif
     for (i = 0; i < Npoints; ++i) {
         /* length of k */
         f = M_2PI / lambda[i];
@@ -1785,9 +1799,11 @@ int ang2q_conversion_linear_sdtrans(
     }
 
     /* calculate rotation matices and perform rotations */
+#ifdef __OPENMP__
     #pragma omp parallel for default(shared) \
             private(i, j, k, f, mtemp, mtemp2, ms, rd) \
             schedule(static)
+#endif
     for (i = 0; i < Npoints; ++i) {
         /* length of k */
         f = M_2PI / lambda[i];
@@ -2125,9 +2141,11 @@ int ang2q_conversion_area(
     }
 
     /* calculate rotation matices and perform rotations */
+#ifdef __OPENMP__
     #pragma omp parallel for default(shared) \
             private(i, j, j1, j2, k, f, mtemp, mtemp2, ms, md, rd, rtemp) \
             schedule(static)
+#endif
     for (i = 0; i < Npoints; ++i) {
         f = M_2PI / lambda[i];
         /* determine sample rotations */
@@ -2268,9 +2286,11 @@ int ang2q_conversion_area_sd(
     }
 
     /* calculate rotation matices and perform rotations */
+#ifdef __OPENMP__
     #pragma omp parallel for default(shared) \
             private(i, j, j1, j2, k, f, mtemp, mtemp2, ms, md, rd, rtemp) \
             schedule(static)
+#endif
     for (i = 0; i < Npoints; ++i) {
         /* length of k */
         f = M_2PI / lambda[i];
@@ -2412,9 +2432,11 @@ int ang2q_conversion_area_trans(
     }
 
     /* calculate rotation matices and perform rotations */
+#ifdef __OPENMP__
     #pragma omp parallel for default(shared) \
             private(i, j, j1, j2, k, f, mtemp, mtemp2, ms, rd) \
             schedule(static)
+#endif
     for (i = 0; i < Npoints; ++i) {
         f = M_2PI / lambda[i];
         /* determine sample rotations */
@@ -2555,9 +2577,11 @@ int ang2q_conversion_area_sdtrans(
     }
 
     /* calculate rotation matices and perform rotations */
+#ifdef __OPENMP__
     #pragma omp parallel for default(shared) \
             private(i, j, j1, j2, k, f, mtemp, mtemp2, ms, rd) \
             schedule(static)
+#endif
     for (i = 0; i < Npoints; ++i) {
         f = M_2PI / lambda[i];
         /* determine sample rotations */
@@ -2739,9 +2763,11 @@ PyObject* ang2q_conversion_area_pixel(PyObject *self, PyObject *args)
     }
 
     /* calculate rotation matices and perform rotations */
+#ifdef __OPENMP__
     #pragma omp parallel for default(shared) \
             private(i, j, k, rd) \
             schedule(static)
+#endif
     for (i = 0; i < Npoints; ++i) {
         /* calculate momentum transfer for the detector pixel n1[i], n2[i] */
         for (k = 0; k < 3; ++k) {
@@ -2936,9 +2962,11 @@ PyObject* ang2q_conversion_area_pixel2(PyObject *self, PyObject *args)
     }
 
     /* calculate rotation matices and perform rotations */
+#ifdef __OPENMP__
     #pragma omp parallel for default(shared) \
             private(i, j, k, mtemp, mtemp2, ms, rd) \
             schedule(static)
+#endif
     for (i = 0; i < Npoints; ++i) {
         /* determine sample rotations */
         ident(mtemp);
@@ -3069,8 +3097,10 @@ PyObject* ang2q_detpos(PyObject *self, PyObject *args)
     }
 
     /* calculate rotation matices and perform rotations */
+#ifdef __OPENMP__
     #pragma omp parallel for default(shared) \
             private(i, j, rd) schedule(static)
+#endif
     for (i = 0; i < Npoints; ++i) {
         /* determine detector rotations */
         veccopy(rd, ri);
@@ -3196,8 +3226,10 @@ PyObject* ang2q_detpos_linear(PyObject *self, PyObject *args)
     }
 
     /* calculate rotation matices and perform rotations */
+#ifdef __OPENMP__
     #pragma omp parallel for default(shared) \
             private(i, j, k, rd) schedule(static)
+#endif
     for (i = 0; i < Npoints; ++i) {
         for (j = roi[0]; j < roi[1]; ++j) {
             for (k = 0; k < 3; ++k) {
@@ -3350,8 +3382,10 @@ PyObject* ang2q_detpos_area(PyObject *self, PyObject *args)
     }
 
     /* calculate rotation matices and perform rotations */
+#ifdef __OPENMP__
     #pragma omp parallel for default(shared) \
             private(i, j, j1, j2, k, rd) schedule(static)
+#endif
     for (i = 0; i < Npoints; ++i) {
         for (j1 = roi[0]; j1 < roi[1]; ++j1) {
             for (j2 = roi[2]; j2 < roi[3]; ++j2) {

--- a/src/xrayutilities.h
+++ b/src/xrayutilities.h
@@ -21,42 +21,7 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <math.h>
-
-/*****************************************************************************
- * NUMPY specific macros and header files
- ****************************************************************************/
-/*
- * need to make some definitions before loading the arrayobject.h
- * header file
- */
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#define PY_ARRAY_UNIQUE_SYMBOL XU_UNIQUE_SYMBOL
-#define NO_IMPORT_ARRAY
-#include <numpy/arrayobject.h>
-
-/*
- * set numpy API specific macros
- */
-#if NPY_FEATURE_VERSION < 0x00000007
-    #define NPY_ARRAY_ALIGNED       NPY_ALIGNED
-    #define NPY_ARRAY_C_CONTIGUOUS  NPY_C_CONTIGUOUS
-#endif
-
-/*
- * define a macro to check a numpy array. This should mabye go into a
- * function in future.
- */
-#define PYARRAY_CHECK(array, dims, type, msg) \
-    array = (PyArrayObject *) PyArray_FROM_OTF((PyObject *) array, \
-                                               type, \
-                                               NPY_ARRAY_C_CONTIGUOUS | \
-                                               NPY_ARRAY_ALIGNED); \
-    if (PyArray_NDIM(array) != dims ||  \
-        PyArray_TYPE(array) != type) {\
-        PyErr_SetString(PyExc_ValueError, msg); \
-        return NULL; \
-    }
-
+#include "array_utils.h"
 
 /*****************************************************************************
  * Windows build related macros


### PR DESCRIPTION
Lots of compile warnings are now resolved. A macro was converted to a function and proper cleanup in case of errors is now implemented. Some function pointers memory was previously not cleaned up and caused a memory leak. This went undetected so long since it affected no big array.

Data types are now more consistently converted to numpy.double before calling any c-code.