### PR TITLE
fix(examples): set nthreads in example script

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+* PowderModel: add some hints on higher memory consumption with more threads
 * correct use of OPENMP in c-code and performance optimization
 * fix a memory leak in the c-code (not freed memory of function pointers)
 * improved error checking and clean up in c-code

--- a/examples/simpack_powdermodel.py
+++ b/examples/simpack_powdermodel.py
@@ -134,4 +134,7 @@ def main():
 
 if __name__ == '__main__':
     multiprocessing.freeze_support()
+    # define a sane number of threads to be used.
+    # Note that the memory consumption increases with the number of threads!
+    xu.config.NTHREADS = 1
     main()

--- a/examples/xrayutilities_user.conf
+++ b/examples/xrayutilities_user.conf
@@ -10,7 +10,7 @@
 
 # The config file with the default parameters is found in the Python installation
 # path of xrayutilities. It is however not recommended to change things there,
-# instead the user-specific config file
+# instead use the user-specific config file
 
 # begin of xrayutilities configuration
 [xrayutilities]
@@ -28,3 +28,11 @@ verbosity=1
 # default energy in eV
 # if energy is given wavelength settings will be ignored
 # energy=8048
+
+# number of threads to use in parallel sections of the code
+nthreads = 2
+#   0: the maximum number of available threads will be used
+#      (as returned by omp_get_max_threads())
+#   n: n-threads will be used
+# Note: that due to overhead connected with the multithreading more threads
+# is not always better!

--- a/src/block_average.c
+++ b/src/block_average.c
@@ -144,15 +144,15 @@ PyObject* block_average2d(PyObject *self, PyObject *args) {
 
     cout = (double *)PyArray_DATA(outarr);
 
-    ii = 0;
 #ifdef _OPENMP
     /* set openmp thread numbers dynamically */
     OMPSETNUMTHREADS(nthreads);
-    #pragma omp parallel for default(shared) private(i,j,k,l,k_end,l_end,sum) schedule(static)
+    #pragma omp parallel for default(shared) private(i,j,ii,jj,k,l,k_end,l_end,sum) schedule(static)
 #endif
     for (i = 0; i < Nch2; i += Nav2) {
-        jj = 0;
+        ii = i / Nav2;
         for (j = 0; j < Nch1; j += Nav1) {
+            jj = j / Nav1;
             sum = 0.0;
             k_end = (i + Nav2 < Nch2) ? i + Nav2 : Nch2;
             l_end = (j + Nav1 < Nch1) ? j + Nav1 : Nch1;
@@ -162,11 +162,8 @@ PyObject* block_average2d(PyObject *self, PyObject *args) {
                 }
             }
             cout[ii * nout[1] + jj] = sum / ((k_end - i) * (l_end - j));
-            ++jj;
         }
-        ++ii;
     }
-
     result = PyArray_Return(outarr);
 
 cleanup:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -76,8 +76,8 @@ cleanup_files = [
 class TestExampleScripts(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        """create temporary config settings.
-        
+        """Create temporary config settings.
+
         Limit number of used threads during the test run of the examples.
         """
         cls.config_file = scriptdir / "xrayutilities.conf"
@@ -105,7 +105,8 @@ class TestExampleScripts(unittest.TestCase):
         try:
             os.remove(cls.config_file)
         except FileNotFoundError:
-            print(f"Warning: Config file {cls.config_file} not found during tearDownClass.")
+            print(f"Warning: Config file {cls.config_file} not found during "
+                  "tearDownClass.")
         for f in cleanup_files:
             try:
                 Path(scriptdir, f).unlink(missing_ok=True)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -15,6 +15,7 @@
 #
 # Copyright (c) 2019-2025 Dominik Kriegner <dominik.kriegner@gmail.com>
 
+import configparser
 import os
 import subprocess
 import sys
@@ -22,7 +23,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-scriptdir = str(Path(__file__).parent.parent / 'examples')
+scriptdir = Path(__file__).parent.parent / 'examples'
 scriptfiles = [
     'simpack_powdermodel.py',
     'simpack_xrd_AlGaAs.py',
@@ -73,9 +74,23 @@ cleanup_files = [
 
 
 class TestExampleScripts(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """create temporary config settings.
+        
+        Limit number of used threads during the test run of the examples.
+        """
+        cls.config_file = scriptdir / "xrayutilities.conf"
+        cls.config = configparser.ConfigParser()
+        cls.config["xrayutilities"] = {"nthreads": "2"}
+
+        with open(cls.config_file, "w") as f:
+            cls.config.write(f)
+
     def test_examples(self):
         """Testrun example scripts."""
         for sf in scriptfiles:
+            print(f"starting script {sf}")
             with self.subTest(script=sf):
                 with tempfile.TemporaryFile(mode='w') as fid:
                     env = os.environ.copy()
@@ -87,6 +102,10 @@ class TestExampleScripts(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         """Clean up any files created during tests."""
+        try:
+            os.remove(cls.config_file)
+        except FileNotFoundError:
+            print(f"Warning: Config file {cls.config_file} not found during tearDownClass.")
         for f in cleanup_files:
             try:
                 Path(scriptdir, f).unlink(missing_ok=True)


### PR DESCRIPTION
It seems tests on windows can stall if the number of threads is automatically determined. This might be a limit on the test systems and in my virtual machine, but generally seems an important thing to make the user aware of!