### PR TITLE
move all pipelines to 3.13 where possible

### DIFF
--- a/.azure/azure-builddocs.yml
+++ b/.azure/azure-builddocs.yml
@@ -1,65 +1,65 @@
 # build documentation (PDF & HTML)
 trigger:
-  tags:
-    include:
-      - v*
+    tags:
+        include:
+            - v*
 
 pr: none
 
 variables:
-  python_version: 3.12
+    python_version: 3.13
 
 pool:
-  vmImage: "ubuntu-latest"
+    vmImage: "ubuntu-latest"
 
 steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: "$(python_version)"
-    displayName: "Use Python $(python_version)"
+    - task: UsePythonVersion@0
+      inputs:
+          versionSpec: "$(python_version)"
+      displayName: "Use Python $(python_version)"
 
-  - script: |
-      python -m pip install --upgrade pip
-      pip install numpy scipy h5py
-    displayName: "Install build dependencies"
+    - script: |
+          python -m pip install --upgrade pip
+          pip install numpy scipy h5py
+      displayName: "Install build dependencies"
 
-  - script: |
-      pip install matplotlib numpydoc rst2pdf sphinx sphinx-pyproject sphinx_rtd_theme svglib
-    displayName: "Install documentation dependencies"
+    - script: |
+          pip install matplotlib numpydoc rst2pdf sphinx sphinx-pyproject sphinx_rtd_theme svglib
+      displayName: "Install documentation dependencies"
 
-  - script: pip install .
-    displayName: "Install xrayutilities"
+    - script: pip install .
+      displayName: "Install xrayutilities"
 
-  - script: |
-      sphinx-apidoc -f -o doc/source lib/xrayutilities
-    displayName: "Generating API documentation"
+    - script: |
+          sphinx-apidoc -f -o doc/source lib/xrayutilities
+      displayName: "Generating API documentation"
 
-  - script: |
-      sphinx-build -b html doc/source build/sphinx/html
-    displayName: "Generating HTML documentation"
+    - script: |
+          sphinx-build -b html doc/source build/sphinx/html
+      displayName: "Generating HTML documentation"
 
-  - script: |
-      # copy to allow regeneration of the patch
-      cp build/sphinx/html/index.html build/sphinx/html/index.html.orig
-      patch -p0 < doc/webpage.patch
-      # in case its needed, update the patch locally using this command
-      # diff -Naur build/sphinx/html/index.html.orig build/sphinx/html/index.html > doc/webpage.patch
-    continueOnError: true
-    displayName: "Patch HTML documentation for webpage"
+    - script: |
+          # copy to allow regeneration of the patch
+          cp build/sphinx/html/index.html build/sphinx/html/index.html.orig
+          patch -p0 < doc/webpage.patch
+          # in case its needed, update the patch locally using this command
+          # diff -Naur build/sphinx/html/index.html.orig build/sphinx/html/index.html > doc/webpage.patch
+      continueOnError: true
+      displayName: "Patch HTML documentation for webpage"
 
-  - script: |
-      sphinx-build -b pdf doc/source build/sphinx/pdf
-      cp build/sphinx/pdf/xrayutilities.pdf build/sphinx/html/
-    displayName: "Generating PDF documentation"
+    - script: |
+          sphinx-build -b pdf doc/source build/sphinx/pdf
+          cp build/sphinx/pdf/xrayutilities.pdf build/sphinx/html/
+      displayName: "Generating PDF documentation"
 
-  # cleanTargetFolder not supported without shell access
-  - task: CopyFilesOverSSH@0
-    inputs:
-      sshEndpoint: "web.sourceforge.net"
-      sourceFolder: "build/sphinx/html"
-      contents: "**"
-      targetFolder: "/home/project-web/xrayutilities/htdocs"
-      cleanTargetFolder: false
-      readyTimeout: "20000"
-      failOnEmptySource: true
-    displayName: "Publish documentation to sourceforge"
+    # cleanTargetFolder not supported without shell access
+    - task: CopyFilesOverSSH@0
+      inputs:
+          sshEndpoint: "web.sourceforge.net"
+          sourceFolder: "build/sphinx/html"
+          contents: "**"
+          targetFolder: "/home/project-web/xrayutilities/htdocs"
+          cleanTargetFolder: false
+          readyTimeout: "20000"
+          failOnEmptySource: true
+      displayName: "Publish documentation to sourceforge"

--- a/.azure/azure-builddocs.yml
+++ b/.azure/azure-builddocs.yml
@@ -1,65 +1,65 @@
 # build documentation (PDF & HTML)
 trigger:
-    tags:
-        include:
-            - v*
+  tags:
+    include:
+      - v*
 
 pr: none
 
 variables:
-    python_version: 3.13
+  python_version: 3.13
 
 pool:
-    vmImage: "ubuntu-latest"
+  vmImage: "ubuntu-latest"
 
 steps:
-    - task: UsePythonVersion@0
-      inputs:
-          versionSpec: "$(python_version)"
-      displayName: "Use Python $(python_version)"
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: "$(python_version)"
+    displayName: "Use Python $(python_version)"
 
-    - script: |
-          python -m pip install --upgrade pip
-          pip install numpy scipy h5py
-      displayName: "Install build dependencies"
+  - script: |
+      python -m pip install --upgrade pip
+      pip install numpy scipy h5py
+    displayName: "Install build dependencies"
 
-    - script: |
-          pip install matplotlib numpydoc rst2pdf sphinx sphinx-pyproject sphinx_rtd_theme svglib
-      displayName: "Install documentation dependencies"
+  - script: |
+      pip install matplotlib numpydoc rst2pdf sphinx sphinx-pyproject sphinx_rtd_theme svglib
+    displayName: "Install documentation dependencies"
 
-    - script: pip install .
-      displayName: "Install xrayutilities"
+  - script: pip install .
+    displayName: "Install xrayutilities"
 
-    - script: |
-          sphinx-apidoc -f -o doc/source lib/xrayutilities
-      displayName: "Generating API documentation"
+  - script: |
+      sphinx-apidoc -f -o doc/source lib/xrayutilities
+    displayName: "Generating API documentation"
 
-    - script: |
-          sphinx-build -b html doc/source build/sphinx/html
-      displayName: "Generating HTML documentation"
+  - script: |
+      sphinx-build -b html doc/source build/sphinx/html
+    displayName: "Generating HTML documentation"
 
-    - script: |
-          # copy to allow regeneration of the patch
-          cp build/sphinx/html/index.html build/sphinx/html/index.html.orig
-          patch -p0 < doc/webpage.patch
-          # in case its needed, update the patch locally using this command
-          # diff -Naur build/sphinx/html/index.html.orig build/sphinx/html/index.html > doc/webpage.patch
-      continueOnError: true
-      displayName: "Patch HTML documentation for webpage"
+  - script: |
+      # copy to allow regeneration of the patch
+      cp build/sphinx/html/index.html build/sphinx/html/index.html.orig
+      patch -p0 < doc/webpage.patch
+      # in case its needed, update the patch locally using this command
+      # diff -Naur build/sphinx/html/index.html.orig build/sphinx/html/index.html > doc/webpage.patch
+    continueOnError: true
+    displayName: "Patch HTML documentation for webpage"
 
-    - script: |
-          sphinx-build -b pdf doc/source build/sphinx/pdf
-          cp build/sphinx/pdf/xrayutilities.pdf build/sphinx/html/
-      displayName: "Generating PDF documentation"
+  - script: |
+      sphinx-build -b pdf doc/source build/sphinx/pdf
+      cp build/sphinx/pdf/xrayutilities.pdf build/sphinx/html/
+    displayName: "Generating PDF documentation"
 
-    # cleanTargetFolder not supported without shell access
-    - task: CopyFilesOverSSH@0
-      inputs:
-          sshEndpoint: "web.sourceforge.net"
-          sourceFolder: "build/sphinx/html"
-          contents: "**"
-          targetFolder: "/home/project-web/xrayutilities/htdocs"
-          cleanTargetFolder: false
-          readyTimeout: "20000"
-          failOnEmptySource: true
-      displayName: "Publish documentation to sourceforge"
+  # cleanTargetFolder not supported without shell access
+  - task: CopyFilesOverSSH@0
+    inputs:
+      sshEndpoint: "web.sourceforge.net"
+      sourceFolder: "build/sphinx/html"
+      contents: "**"
+      targetFolder: "/home/project-web/xrayutilities/htdocs"
+      cleanTargetFolder: false
+      readyTimeout: "20000"
+      failOnEmptySource: true
+    displayName: "Publish documentation to sourceforge"

--- a/.azure/azure-buildwheels.yml
+++ b/.azure/azure-buildwheels.yml
@@ -2,111 +2,111 @@ name: $(Date:yyyyMMdd)$(Rev:rr)
 
 # trigger build only after successful test on main-branch
 resources:
-  pipelines:
-    - pipeline: testing
-      source: testing
-      trigger:
-        branches:
-          include:
-            - refs/head/main
-            - refs/tags/v*
+    pipelines:
+        - pipeline: testing
+          source: testing
+          trigger:
+              branches:
+                  include:
+                      - refs/head/main
+                      - refs/tags/v*
 
 trigger: none
 pr: none
 
 variables:
-  CIBW_BUILD: cp39-* cp310-* cp311-* cp312-* cp313-*
-  CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
-  CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-  CIBW_BUILD_VERBOSITY: 1
-  CIBW_CONFIG_SETTINGS_MACOS: "setup-args=-Duse_openmp=auto"
-  python_version: 3.12
+    CIBW_BUILD: cp39-* cp310-* cp311-* cp312-* cp313-*
+    CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
+    CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+    CIBW_BUILD_VERBOSITY: 1
+    CIBW_CONFIG_SETTINGS_MACOS: "setup-args=-Duse_openmp=auto"
+    python_version: 3.13
 
 strategy:
-  matrix:
-    linux:
-      imageName: "ubuntu-latest"
-    mac:
-      imageName: "macOS-latest"
-    windows:
-      imageName: "windows-latest"
+    matrix:
+        linux:
+            imageName: "ubuntu-latest"
+        mac:
+            imageName: "macOS-latest"
+        windows:
+            imageName: "windows-latest"
 
 pool:
-  vmImage: $(imageName)
+    vmImage: $(imageName)
 
 steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: "$(python_version)"
-    displayName: "Use Python $(python_version)"
+    - task: UsePythonVersion@0
+      inputs:
+          versionSpec: "$(python_version)"
+      displayName: "Use Python $(python_version)"
 
-  # Install dependencies for Linux and macOS
-  - bash: |
-      set -o errexit
-      python3 -m pip install --upgrade pip
-      pip3 install build cibuildwheel twine meson
-    condition: or(eq(variables['Agent.OS'], 'Linux'), eq(variables['Agent.OS'], 'Darwin'))
-    displayName: Install dependencies on Linux/macOS
+    # Install dependencies for Linux and macOS
+    - bash: |
+          set -o errexit
+          python3 -m pip install --upgrade pip
+          pip3 install build cibuildwheel twine meson
+      condition: or(eq(variables['Agent.OS'], 'Linux'), eq(variables['Agent.OS'], 'Darwin'))
+      displayName: Install dependencies on Linux/macOS
 
-  # Install dependencies for Windows
-  - bash: |
-      set -o errexit
-      python -m pip install --upgrade pip
-      pip install build cibuildwheel twine meson
-    condition: eq(variables['Agent.OS'], 'Windows_NT')
-    displayName: Install dependencies on Windows
+    # Install dependencies for Windows
+    - bash: |
+          set -o errexit
+          python -m pip install --upgrade pip
+          pip install build cibuildwheel twine meson
+      condition: eq(variables['Agent.OS'], 'Windows_NT')
+      displayName: Install dependencies on Windows
 
-  - bash: |
-      VERSION=$(git describe --tags --always)
-      VERSION=$(echo "$VERSION" | sed 's/^v//') # Remove leading 'v'
-      if [[ "$VERSION" == *"-"* ]]; then
-        parts=(${VERSION//-/ })
-        tag="${parts[0]}"
-        distance="${parts[1]}"
-        hash="${parts[2]}"
-        VERSION="${tag}+${distance}.${hash}" # Combine with + and .
-      fi
-      echo "Setting version to: $VERSION"
-      meson rewrite kwargs set project / version "$VERSION"
-    condition: and(succeeded(), or(eq(variables['Agent.OS'], 'Linux'), eq(variables['Agent.OS'], 'Darwin')), not(startsWith(variables['build.sourceBranch'], 'refs/tags/')))
-    displayName: Set version from Git on Linux/macOS
+    - bash: |
+          VERSION=$(git describe --tags --always)
+          VERSION=$(echo "$VERSION" | sed 's/^v//') # Remove leading 'v'
+          if [[ "$VERSION" == *"-"* ]]; then
+            parts=(${VERSION//-/ })
+            tag="${parts[0]}"
+            distance="${parts[1]}"
+            hash="${parts[2]}"
+            VERSION="${tag}+${distance}.${hash}" # Combine with + and .
+          fi
+          echo "Setting version to: $VERSION"
+          meson rewrite kwargs set project / version "$VERSION"
+      condition: and(succeeded(), or(eq(variables['Agent.OS'], 'Linux'), eq(variables['Agent.OS'], 'Darwin')), not(startsWith(variables['build.sourceBranch'], 'refs/tags/')))
+      displayName: Set version from Git on Linux/macOS
 
-  - powershell: |
-      $VERSION = git describe --tags --always
-      $VERSION = $VERSION -replace '^v', '' # Remove leading 'v'
+    - powershell: |
+          $VERSION = git describe --tags --always
+          $VERSION = $VERSION -replace '^v', '' # Remove leading 'v'
 
-      if ($VERSION -match '-') {
-        $parts = $VERSION -split '-'
-        $tag = $parts[0]
-        $distance = $parts[1]
-        $hash = $parts[2]
-        $VERSION = "$tag+$distance.$hash" # Combine with + and .
-      }
+          if ($VERSION -match '-') {
+            $parts = $VERSION -split '-'
+            $tag = $parts[0]
+            $distance = $parts[1]
+            $hash = $parts[2]
+            $VERSION = "$tag+$distance.$hash" # Combine with + and .
+          }
 
-      meson rewrite kwargs set project / version $VERSION
-      Write-Host "meson.build updated to version: $VERSION"
-    condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), not(startsWith(variables['build.sourceBranch'], 'refs/tags/')))
-    displayName: Set version from Git on Windows
+          meson rewrite kwargs set project / version $VERSION
+          Write-Host "meson.build updated to version: $VERSION"
+      condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), not(startsWith(variables['build.sourceBranch'], 'refs/tags/')))
+      displayName: Set version from Git on Windows
 
-  # Build sdist (only on Linux)
-  - bash: python3 -m build --sdist
-    condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
-    displayName: Build sdist
+    # Build sdist (only on Linux)
+    - bash: python3 -m build --sdist
+      condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+      displayName: Build sdist
 
-  # Build wheels
-  - bash: cibuildwheel --output-dir wheelhouse .
-    displayName: Build wheels
+    # Build wheels
+    - bash: cibuildwheel --output-dir wheelhouse .
+      displayName: Build wheels
 
-  # Authenticate for publishing
-  - task: TwineAuthenticate@0
-    inputs:
-      artifactFeeds: "xrayutilities/xrayutilities-dev"
+    # Authenticate for publishing
+    - task: TwineAuthenticate@0
+      inputs:
+          artifactFeeds: "xrayutilities/xrayutilities-dev"
 
-  # Publish wheels
-  - script: "twine upload -r xrayutilities/xrayutilities-dev --config-file $(PYPIRC_PATH) wheelhouse/*"
-    displayName: Publish Wheels
+    # Publish wheels
+    - script: "twine upload -r xrayutilities/xrayutilities-dev --config-file $(PYPIRC_PATH) wheelhouse/*"
+      displayName: Publish Wheels
 
-  # Publish sdist (only on Linux)
-  - script: "twine upload -r xrayutilities/xrayutilities-dev --config-file $(PYPIRC_PATH) dist/*"
-    condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
-    displayName: Publish sdist
+    # Publish sdist (only on Linux)
+    - script: "twine upload -r xrayutilities/xrayutilities-dev --config-file $(PYPIRC_PATH) dist/*"
+      condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+      displayName: Publish sdist

--- a/.azure/azure-buildwheels.yml
+++ b/.azure/azure-buildwheels.yml
@@ -2,111 +2,111 @@ name: $(Date:yyyyMMdd)$(Rev:rr)
 
 # trigger build only after successful test on main-branch
 resources:
-    pipelines:
-        - pipeline: testing
-          source: testing
-          trigger:
-              branches:
-                  include:
-                      - refs/head/main
-                      - refs/tags/v*
+  pipelines:
+    - pipeline: testing
+      source: testing
+      trigger:
+        branches:
+          include:
+            - refs/head/main
+            - refs/tags/v*
 
 trigger: none
 pr: none
 
 variables:
-    CIBW_BUILD: cp39-* cp310-* cp311-* cp312-* cp313-*
-    CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
-    CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-    CIBW_BUILD_VERBOSITY: 1
-    CIBW_CONFIG_SETTINGS_MACOS: "setup-args=-Duse_openmp=auto"
-    python_version: 3.13
+  CIBW_BUILD: cp39-* cp310-* cp311-* cp312-* cp313-*
+  CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
+  CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+  CIBW_BUILD_VERBOSITY: 1
+  CIBW_CONFIG_SETTINGS_MACOS: "setup-args=-Duse_openmp=auto"
+  python_version: 3.13
 
 strategy:
-    matrix:
-        linux:
-            imageName: "ubuntu-latest"
-        mac:
-            imageName: "macOS-latest"
-        windows:
-            imageName: "windows-latest"
+  matrix:
+    linux:
+      imageName: "ubuntu-latest"
+    mac:
+      imageName: "macOS-latest"
+    windows:
+      imageName: "windows-latest"
 
 pool:
-    vmImage: $(imageName)
+  vmImage: $(imageName)
 
 steps:
-    - task: UsePythonVersion@0
-      inputs:
-          versionSpec: "$(python_version)"
-      displayName: "Use Python $(python_version)"
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: "$(python_version)"
+    displayName: "Use Python $(python_version)"
 
-    # Install dependencies for Linux and macOS
-    - bash: |
-          set -o errexit
-          python3 -m pip install --upgrade pip
-          pip3 install build cibuildwheel twine meson
-      condition: or(eq(variables['Agent.OS'], 'Linux'), eq(variables['Agent.OS'], 'Darwin'))
-      displayName: Install dependencies on Linux/macOS
+  # Install dependencies for Linux and macOS
+  - bash: |
+      set -o errexit
+      python3 -m pip install --upgrade pip
+      pip3 install build cibuildwheel twine meson
+    condition: or(eq(variables['Agent.OS'], 'Linux'), eq(variables['Agent.OS'], 'Darwin'))
+    displayName: Install dependencies on Linux/macOS
 
-    # Install dependencies for Windows
-    - bash: |
-          set -o errexit
-          python -m pip install --upgrade pip
-          pip install build cibuildwheel twine meson
-      condition: eq(variables['Agent.OS'], 'Windows_NT')
-      displayName: Install dependencies on Windows
+  # Install dependencies for Windows
+  - bash: |
+      set -o errexit
+      python -m pip install --upgrade pip
+      pip install build cibuildwheel twine meson
+    condition: eq(variables['Agent.OS'], 'Windows_NT')
+    displayName: Install dependencies on Windows
 
-    - bash: |
-          VERSION=$(git describe --tags --always)
-          VERSION=$(echo "$VERSION" | sed 's/^v//') # Remove leading 'v'
-          if [[ "$VERSION" == *"-"* ]]; then
-            parts=(${VERSION//-/ })
-            tag="${parts[0]}"
-            distance="${parts[1]}"
-            hash="${parts[2]}"
-            VERSION="${tag}+${distance}.${hash}" # Combine with + and .
-          fi
-          echo "Setting version to: $VERSION"
-          meson rewrite kwargs set project / version "$VERSION"
-      condition: and(succeeded(), or(eq(variables['Agent.OS'], 'Linux'), eq(variables['Agent.OS'], 'Darwin')), not(startsWith(variables['build.sourceBranch'], 'refs/tags/')))
-      displayName: Set version from Git on Linux/macOS
+  - bash: |
+      VERSION=$(git describe --tags --always)
+      VERSION=$(echo "$VERSION" | sed 's/^v//') # Remove leading 'v'
+      if [[ "$VERSION" == *"-"* ]]; then
+        parts=(${VERSION//-/ })
+        tag="${parts[0]}"
+        distance="${parts[1]}"
+        hash="${parts[2]}"
+        VERSION="${tag}+${distance}.${hash}" # Combine with + and .
+      fi
+      echo "Setting version to: $VERSION"
+      meson rewrite kwargs set project / version "$VERSION"
+    condition: and(succeeded(), or(eq(variables['Agent.OS'], 'Linux'), eq(variables['Agent.OS'], 'Darwin')), not(startsWith(variables['build.sourceBranch'], 'refs/tags/')))
+    displayName: Set version from Git on Linux/macOS
 
-    - powershell: |
-          $VERSION = git describe --tags --always
-          $VERSION = $VERSION -replace '^v', '' # Remove leading 'v'
+  - powershell: |
+      $VERSION = git describe --tags --always
+      $VERSION = $VERSION -replace '^v', '' # Remove leading 'v'
 
-          if ($VERSION -match '-') {
-            $parts = $VERSION -split '-'
-            $tag = $parts[0]
-            $distance = $parts[1]
-            $hash = $parts[2]
-            $VERSION = "$tag+$distance.$hash" # Combine with + and .
-          }
+      if ($VERSION -match '-') {
+        $parts = $VERSION -split '-'
+        $tag = $parts[0]
+        $distance = $parts[1]
+        $hash = $parts[2]
+        $VERSION = "$tag+$distance.$hash" # Combine with + and .
+      }
 
-          meson rewrite kwargs set project / version $VERSION
-          Write-Host "meson.build updated to version: $VERSION"
-      condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), not(startsWith(variables['build.sourceBranch'], 'refs/tags/')))
-      displayName: Set version from Git on Windows
+      meson rewrite kwargs set project / version $VERSION
+      Write-Host "meson.build updated to version: $VERSION"
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), not(startsWith(variables['build.sourceBranch'], 'refs/tags/')))
+    displayName: Set version from Git on Windows
 
-    # Build sdist (only on Linux)
-    - bash: python3 -m build --sdist
-      condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
-      displayName: Build sdist
+  # Build sdist (only on Linux)
+  - bash: python3 -m build --sdist
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+    displayName: Build sdist
 
-    # Build wheels
-    - bash: cibuildwheel --output-dir wheelhouse .
-      displayName: Build wheels
+  # Build wheels
+  - bash: cibuildwheel --output-dir wheelhouse .
+    displayName: Build wheels
 
-    # Authenticate for publishing
-    - task: TwineAuthenticate@0
-      inputs:
-          artifactFeeds: "xrayutilities/xrayutilities-dev"
+  # Authenticate for publishing
+  - task: TwineAuthenticate@0
+    inputs:
+      artifactFeeds: "xrayutilities/xrayutilities-dev"
 
-    # Publish wheels
-    - script: "twine upload -r xrayutilities/xrayutilities-dev --config-file $(PYPIRC_PATH) wheelhouse/*"
-      displayName: Publish Wheels
+  # Publish wheels
+  - script: "twine upload -r xrayutilities/xrayutilities-dev --config-file $(PYPIRC_PATH) wheelhouse/*"
+    displayName: Publish Wheels
 
-    # Publish sdist (only on Linux)
-    - script: "twine upload -r xrayutilities/xrayutilities-dev --config-file $(PYPIRC_PATH) dist/*"
-      condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
-      displayName: Publish sdist
+  # Publish sdist (only on Linux)
+  - script: "twine upload -r xrayutilities/xrayutilities-dev --config-file $(PYPIRC_PATH) dist/*"
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+    displayName: Publish sdist

--- a/.azure/azure-testing.yml
+++ b/.azure/azure-testing.yml
@@ -1,63 +1,63 @@
 name: $(BuildDefinitionName)_$(Date:yyyyMMdd)$(Rev:.rr)
 
 trigger:
-  branches:
-    include:
-      - main
-  tags:
-    include:
-      - v*
+    branches:
+        include:
+            - main
+    tags:
+        include:
+            - v*
 
 jobs:
-  - job:
-    displayName: "Linting"
-    pool:
-      vmImage: "ubuntu-latest"
-    variables:
-      srcDirectory: lib
-      testsDirectory: tests
-      examplesDirectory: examples
-    steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: "3.12"
-      - script: pip install -r recommended_requirements.txt
-        # needed to help pylint analyze our code
-        displayName: "Install package requirements"
+    - job:
+      displayName: "Linting"
+      pool:
+          vmImage: "ubuntu-latest"
+      variables:
+          srcDirectory: lib
+          testsDirectory: tests
+          examplesDirectory: examples
+      steps:
+          - task: UsePythonVersion@0
+            inputs:
+                versionSpec: "3.13"
+          - script: pip install -r recommended_requirements.txt
+            # needed to help pylint analyze our code
+            displayName: "Install package requirements"
 
-      - script: pip install -v .
-        # need to install in order to generate C-extension
-        displayName: "Install xrayutilities"
+          - script: pip install -v .
+            # need to install in order to generate C-extension
+            displayName: "Install xrayutilities"
 
-      - script: pip install pylint flake8 flake8-pyproject
-        displayName: "Install packages for linting"
+          - script: pip install pylint flake8 flake8-pyproject
+            displayName: "Install packages for linting"
 
-      - script: pylint xrayutilities
-        displayName: "Linting: pylint"
-        continueOnError: true
+          - script: pylint xrayutilities
+            displayName: "Linting: pylint"
+            continueOnError: true
 
-      - script: flake8 $(srcDirectory) $(testsDirectory) $(examplesDirectory)
-        displayName: "Linting: flake8"
+          - script: flake8 $(srcDirectory) $(testsDirectory) $(examplesDirectory)
+            displayName: "Linting: flake8"
 
-  - template: templates/testing_job.yml
-    parameters:
-      name: "Linux"
-      vmImage: "ubuntu-latest"
+    - template: templates/testing_job.yml
+      parameters:
+          name: "Linux"
+          vmImage: "ubuntu-latest"
 
-  - template: templates/testing_job.yml
-    parameters:
-      name: "macOS"
-      vmImage: "macOS-latest"
+    - template: templates/testing_job.yml
+      parameters:
+          name: "macOS"
+          vmImage: "macOS-latest"
 
-  - template: templates/testing_job.yml
-    parameters:
-      name: "Windows"
-      vmImage: "windows-latest"
+    - template: templates/testing_job.yml
+      parameters:
+          name: "Windows"
+          vmImage: "windows-latest"
 
 schedules:
-  - cron: "0 4 1 * *"
-    displayName: Monthly build
-    branches:
-      include:
-        - main
-    always: true
+    - cron: "0 4 1 * *"
+      displayName: Monthly build
+      branches:
+          include:
+              - main
+      always: true

--- a/.azure/azure-testing.yml
+++ b/.azure/azure-testing.yml
@@ -1,63 +1,63 @@
 name: $(BuildDefinitionName)_$(Date:yyyyMMdd)$(Rev:.rr)
 
 trigger:
-    branches:
-        include:
-            - main
-    tags:
-        include:
-            - v*
+  branches:
+    include:
+      - main
+  tags:
+    include:
+      - v*
 
 jobs:
-    - job:
-      displayName: "Linting"
-      pool:
-          vmImage: "ubuntu-latest"
-      variables:
-          srcDirectory: lib
-          testsDirectory: tests
-          examplesDirectory: examples
-      steps:
-          - task: UsePythonVersion@0
-            inputs:
-                versionSpec: "3.13"
-          - script: pip install -r recommended_requirements.txt
-            # needed to help pylint analyze our code
-            displayName: "Install package requirements"
+  - job:
+    displayName: "Linting"
+    pool:
+      vmImage: "ubuntu-latest"
+    variables:
+      srcDirectory: lib
+      testsDirectory: tests
+      examplesDirectory: examples
+    steps:
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: "3.13"
+      - script: pip install -r recommended_requirements.txt
+        # needed to help pylint analyze our code
+        displayName: "Install package requirements"
 
-          - script: pip install -v .
-            # need to install in order to generate C-extension
-            displayName: "Install xrayutilities"
+      - script: pip install -v .
+        # need to install in order to generate C-extension
+        displayName: "Install xrayutilities"
 
-          - script: pip install pylint flake8 flake8-pyproject
-            displayName: "Install packages for linting"
+      - script: pip install pylint flake8 flake8-pyproject
+        displayName: "Install packages for linting"
 
-          - script: pylint xrayutilities
-            displayName: "Linting: pylint"
-            continueOnError: true
+      - script: pylint xrayutilities
+        displayName: "Linting: pylint"
+        continueOnError: true
 
-          - script: flake8 $(srcDirectory) $(testsDirectory) $(examplesDirectory)
-            displayName: "Linting: flake8"
+      - script: flake8 $(srcDirectory) $(testsDirectory) $(examplesDirectory)
+        displayName: "Linting: flake8"
 
-    - template: templates/testing_job.yml
-      parameters:
-          name: "Linux"
-          vmImage: "ubuntu-latest"
+  - template: templates/testing_job.yml
+    parameters:
+      name: "Linux"
+      vmImage: "ubuntu-latest"
 
-    - template: templates/testing_job.yml
-      parameters:
-          name: "macOS"
-          vmImage: "macOS-latest"
+  - template: templates/testing_job.yml
+    parameters:
+      name: "macOS"
+      vmImage: "macOS-latest"
 
-    - template: templates/testing_job.yml
-      parameters:
-          name: "Windows"
-          vmImage: "windows-latest"
+  - template: templates/testing_job.yml
+    parameters:
+      name: "Windows"
+      vmImage: "windows-latest"
 
 schedules:
-    - cron: "0 4 1 * *"
-      displayName: Monthly build
-      branches:
-          include:
-              - main
-      always: true
+  - cron: "0 4 1 * *"
+    displayName: Monthly build
+    branches:
+      include:
+        - main
+    always: true

--- a/.azure/templates/testing_job.yml
+++ b/.azure/templates/testing_job.yml
@@ -15,7 +15,7 @@ jobs:
         Python312:
           python.version: "3.12"
         Python313:
-          python_version: "3.13"
+          python.version: "3.13"
 
     steps:
       - task: UsePythonVersion@0

--- a/.azure/templates/testing_job.yml
+++ b/.azure/templates/testing_job.yml
@@ -1,82 +1,82 @@
 parameters:
-    - name: name
-      default: ""
-    - name: vmImage
-      default: ""
+  - name: name
+    default: ""
+  - name: vmImage
+    default: ""
 
 jobs:
-    - job: ${{ parameters.name }}
-      pool:
-          vmImage: ${{ parameters.vmImage }}
-      strategy:
-          matrix:
-              Python39:
-                  python.version: "3.9"
-              Python312:
-                  python.version: "3.12"
-              Python313:
-                  python_version: "3.13"
+  - job: ${{ parameters.name }}
+    pool:
+      vmImage: ${{ parameters.vmImage }}
+    strategy:
+      matrix:
+        Python39:
+          python.version: "3.9"
+        Python312:
+          python.version: "3.12"
+        Python313:
+          python_version: "3.13"
 
-      steps:
-          - task: UsePythonVersion@0
-            inputs:
-                versionSpec: "$(python.version)"
-          - task: Cache@2
-            inputs:
-                key: testdata20250118
-                path: $(System.DefaultWorkingDirectory)/tests/data
-                cacheHitVar: TESTDATA_RESTORED
-            condition: and(succeeded(), eq(variables['python.version'], '3.13'))
-            displayName: Cache test data
-          - script: |
-                curl -s -L https://sourceforge.net/projects/xrayutilities/files/xrayutilities-testdata-20250118.tar.gz -o xu_testdata.tar.gz
-                tar xzf xu_testdata.tar.gz -C tests
-            condition: and(succeeded(), ne(variables['TESTDATA_RESTORED'], 'true'), eq(variables['python.version'], '3.13'))
-            displayName: Download test data
-          - script: |
-                pip install -r recommended_requirements.txt
-            displayName: Install requirements
-          - script: |
-                pip install meson-python meson ninja
-            displayName: Install build time requirements (editable installation)
-          - script: |
-                pip install coverage[toml] pytest pytest-cov pytest-azurepipelines pytest-subtests
-            displayName: Install test requirements
-          - script: |
-                pip install -v ".[plot]"
-            displayName: "Install xrayutilities"
-            condition: eq(variables['Agent.OS'], 'Linux')
-          - script: |
-                pip install -v --config-settings=setup-args="--vsenv" ".[plot]"
-            condition: eq(variables['Agent.OS'], 'Windows_NT')
-            displayName: "Install xrayutilities with MSVC (Windows)"
-          - script: |
-                pip install -v --config-settings=setup-args="-Duse_openmp=auto" ".[plot]"
-            condition: eq(variables['Agent.OS'], 'Darwin')
-            displayName: "Install xrayutilities with optional OpenMP (MacOS)"
-          - script: |
-                pytest --junitxml=junit/test-results.xml --cov --cov-config pyproject.toml --cov-report=xml --doctest-glob="*.rst"
-            displayName: Run pytest
-          - script: |
-                pip install --no-build-isolation --editable .
-            condition: eq(variables['Agent.OS'], 'Linux')
-            displayName: Perform editable installation
-          - script: |
-                pip install --no-build-isolation --config-settings=setup-args="--vsenv" --editable .
-            condition: eq(variables['Agent.OS'], 'Windows_NT')
-            displayName: Perform editable installation (Windows)
-          - script: |
-                pip install --no-build-isolation --config-settings=setup-args="-Duse_openmp=auto" --editable .
-            condition: eq(variables['Agent.OS'], 'Darwin')
-            displayName: Perform editable installation (MacOS)
-          - script: |
-                pytest --junitxml=junit/test-results.xml --cov --cov-append --cov-config pyproject.toml --cov-report=xml --doctest-modules  --ignore=lib/xrayutilities/materials/_create_database.py lib
-            displayName: Run doctest modules
-          - task: PublishTestResults@2
-            condition: succeededOrFailed()
-            inputs:
-                testResultsFiles: "**/test-*.xml"
-                testRunTitle: "Publish test results for Python $(python.version)"
-          - task: PublishCodeCoverageResults@2
-            inputs:
-                summaryFileLocation: "$(System.DefaultWorkingDirectory)/**/coverage.xml"
+    steps:
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: "$(python.version)"
+      - task: Cache@2
+        inputs:
+          key: testdata20250118
+          path: $(System.DefaultWorkingDirectory)/tests/data
+          cacheHitVar: TESTDATA_RESTORED
+        condition: and(succeeded(), eq(variables['python.version'], '3.13'))
+        displayName: Cache test data
+      - script: |
+          curl -s -L https://sourceforge.net/projects/xrayutilities/files/xrayutilities-testdata-20250118.tar.gz -o xu_testdata.tar.gz
+          tar xzf xu_testdata.tar.gz -C tests
+        condition: and(succeeded(), ne(variables['TESTDATA_RESTORED'], 'true'), eq(variables['python.version'], '3.13'))
+        displayName: Download test data
+      - script: |
+          pip install -r recommended_requirements.txt
+        displayName: Install requirements
+      - script: |
+          pip install meson-python meson ninja
+        displayName: Install build time requirements (editable installation)
+      - script: |
+          pip install coverage[toml] pytest pytest-cov pytest-azurepipelines pytest-subtests
+        displayName: Install test requirements
+      - script: |
+          pip install -v ".[plot]"
+        displayName: "Install xrayutilities"
+        condition: eq(variables['Agent.OS'], 'Linux')
+      - script: |
+          pip install -v --config-settings=setup-args="--vsenv" ".[plot]"
+        condition: eq(variables['Agent.OS'], 'Windows_NT')
+        displayName: "Install xrayutilities with MSVC (Windows)"
+      - script: |
+          pip install -v --config-settings=setup-args="-Duse_openmp=auto" ".[plot]"
+        condition: eq(variables['Agent.OS'], 'Darwin')
+        displayName: "Install xrayutilities with optional OpenMP (MacOS)"
+      - script: |
+          pytest --junitxml=junit/test-results.xml --cov --cov-config pyproject.toml --cov-report=xml --doctest-glob="*.rst"
+        displayName: Run pytest
+      - script: |
+          pip install --no-build-isolation --editable .
+        condition: eq(variables['Agent.OS'], 'Linux')
+        displayName: Perform editable installation
+      - script: |
+          pip install --no-build-isolation --config-settings=setup-args="--vsenv" --editable .
+        condition: eq(variables['Agent.OS'], 'Windows_NT')
+        displayName: Perform editable installation (Windows)
+      - script: |
+          pip install --no-build-isolation --config-settings=setup-args="-Duse_openmp=auto" --editable .
+        condition: eq(variables['Agent.OS'], 'Darwin')
+        displayName: Perform editable installation (MacOS)
+      - script: |
+          pytest --junitxml=junit/test-results.xml --cov --cov-append --cov-config pyproject.toml --cov-report=xml --doctest-modules  --ignore=lib/xrayutilities/materials/_create_database.py lib
+        displayName: Run doctest modules
+      - task: PublishTestResults@2
+        condition: succeededOrFailed()
+        inputs:
+          testResultsFiles: "**/test-*.xml"
+          testRunTitle: "Publish test results for Python $(python.version)"
+      - task: PublishCodeCoverageResults@2
+        inputs:
+          summaryFileLocation: "$(System.DefaultWorkingDirectory)/**/coverage.xml"

--- a/.azure/templates/testing_job.yml
+++ b/.azure/templates/testing_job.yml
@@ -1,84 +1,82 @@
 parameters:
-  - name: name
-    default: ""
-  - name: vmImage
-    default: ""
+    - name: name
+      default: ""
+    - name: vmImage
+      default: ""
 
 jobs:
-  - job: ${{ parameters.name }}
-    pool:
-      vmImage: ${{ parameters.vmImage }}
-    strategy:
-      matrix:
-        Python39:
-          python.version: "3.9"
-        Python310:
-          python.version: "3.10"
-        Python311:
-          python.version: "3.11"
-        Python312:
-          python.version: "3.12"
+    - job: ${{ parameters.name }}
+      pool:
+          vmImage: ${{ parameters.vmImage }}
+      strategy:
+          matrix:
+              Python39:
+                  python.version: "3.9"
+              Python312:
+                  python.version: "3.12"
+              Python313:
+                  python_version: "3.13"
 
-    steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: "$(python.version)"
-      - task: Cache@2
-        inputs:
-          key: testdata20250118
-          path: $(System.DefaultWorkingDirectory)/tests/data
-          cacheHitVar: TESTDATA_RESTORED
-        condition: and(succeeded(), eq(variables['python.version'], '3.12'))
-        displayName: Cache test data
-      - script: |
-          curl -s -L https://sourceforge.net/projects/xrayutilities/files/xrayutilities-testdata-20250118.tar.gz -o xu_testdata.tar.gz
-          tar xzf xu_testdata.tar.gz -C tests
-        condition: and(succeeded(), ne(variables['TESTDATA_RESTORED'], 'true'), eq(variables['python.version'], '3.12'))
-        displayName: Download test data
-      - script: |
-          pip install -r recommended_requirements.txt
-        displayName: Install requirements
-      - script: |
-          pip install meson-python meson ninja
-        displayName: Install build time requirements (editable installation)
-      - script: |
-          pip install coverage[toml] pytest pytest-cov pytest-azurepipelines pytest-subtests
-        displayName: Install test requirements
-      - script: |
-          pip install -v ".[plot]"
-        displayName: "Install xrayutilities"
-        condition: eq(variables['Agent.OS'], 'Linux')
-      - script: |
-          pip install -v --config-settings=setup-args="--vsenv" ".[plot]"
-        condition: eq(variables['Agent.OS'], 'Windows_NT')
-        displayName: "Install xrayutilities with MSVC (Windows)"
-      - script: |
-          pip install -v --config-settings=setup-args="-Duse_openmp=auto" ".[plot]"
-        condition: eq(variables['Agent.OS'], 'Darwin')
-        displayName: "Install xrayutilities with optional OpenMP (MacOS)"
-      - script: |
-          pytest --junitxml=junit/test-results.xml --cov --cov-config pyproject.toml --cov-report=xml --doctest-glob="*.rst"
-        displayName: Run pytest
-      - script: |
-          pip install --no-build-isolation --editable .
-        condition: eq(variables['Agent.OS'], 'Linux')
-        displayName: Perform editable installation
-      - script: |
-          pip install --no-build-isolation --config-settings=setup-args="--vsenv" --editable .
-        condition: eq(variables['Agent.OS'], 'Windows_NT')
-        displayName: Perform editable installation (Windows)
-      - script: |
-          pip install --no-build-isolation --config-settings=setup-args="-Duse_openmp=auto" --editable .
-        condition: eq(variables['Agent.OS'], 'Darwin')
-        displayName: Perform editable installation (MacOS)
-      - script: |
-          pytest --junitxml=junit/test-results.xml --cov --cov-append --cov-config pyproject.toml --cov-report=xml --doctest-modules  --ignore=lib/xrayutilities/materials/_create_database.py lib
-        displayName: Run doctest modules
-      - task: PublishTestResults@2
-        condition: succeededOrFailed()
-        inputs:
-          testResultsFiles: "**/test-*.xml"
-          testRunTitle: "Publish test results for Python $(python.version)"
-      - task: PublishCodeCoverageResults@2
-        inputs:
-          summaryFileLocation: "$(System.DefaultWorkingDirectory)/**/coverage.xml"
+      steps:
+          - task: UsePythonVersion@0
+            inputs:
+                versionSpec: "$(python.version)"
+          - task: Cache@2
+            inputs:
+                key: testdata20250118
+                path: $(System.DefaultWorkingDirectory)/tests/data
+                cacheHitVar: TESTDATA_RESTORED
+            condition: and(succeeded(), eq(variables['python.version'], '3.13'))
+            displayName: Cache test data
+          - script: |
+                curl -s -L https://sourceforge.net/projects/xrayutilities/files/xrayutilities-testdata-20250118.tar.gz -o xu_testdata.tar.gz
+                tar xzf xu_testdata.tar.gz -C tests
+            condition: and(succeeded(), ne(variables['TESTDATA_RESTORED'], 'true'), eq(variables['python.version'], '3.13'))
+            displayName: Download test data
+          - script: |
+                pip install -r recommended_requirements.txt
+            displayName: Install requirements
+          - script: |
+                pip install meson-python meson ninja
+            displayName: Install build time requirements (editable installation)
+          - script: |
+                pip install coverage[toml] pytest pytest-cov pytest-azurepipelines pytest-subtests
+            displayName: Install test requirements
+          - script: |
+                pip install -v ".[plot]"
+            displayName: "Install xrayutilities"
+            condition: eq(variables['Agent.OS'], 'Linux')
+          - script: |
+                pip install -v --config-settings=setup-args="--vsenv" ".[plot]"
+            condition: eq(variables['Agent.OS'], 'Windows_NT')
+            displayName: "Install xrayutilities with MSVC (Windows)"
+          - script: |
+                pip install -v --config-settings=setup-args="-Duse_openmp=auto" ".[plot]"
+            condition: eq(variables['Agent.OS'], 'Darwin')
+            displayName: "Install xrayutilities with optional OpenMP (MacOS)"
+          - script: |
+                pytest --junitxml=junit/test-results.xml --cov --cov-config pyproject.toml --cov-report=xml --doctest-glob="*.rst"
+            displayName: Run pytest
+          - script: |
+                pip install --no-build-isolation --editable .
+            condition: eq(variables['Agent.OS'], 'Linux')
+            displayName: Perform editable installation
+          - script: |
+                pip install --no-build-isolation --config-settings=setup-args="--vsenv" --editable .
+            condition: eq(variables['Agent.OS'], 'Windows_NT')
+            displayName: Perform editable installation (Windows)
+          - script: |
+                pip install --no-build-isolation --config-settings=setup-args="-Duse_openmp=auto" --editable .
+            condition: eq(variables['Agent.OS'], 'Darwin')
+            displayName: Perform editable installation (MacOS)
+          - script: |
+                pytest --junitxml=junit/test-results.xml --cov --cov-append --cov-config pyproject.toml --cov-report=xml --doctest-modules  --ignore=lib/xrayutilities/materials/_create_database.py lib
+            displayName: Run doctest modules
+          - task: PublishTestResults@2
+            condition: succeededOrFailed()
+            inputs:
+                testResultsFiles: "**/test-*.xml"
+                testRunTitle: "Publish test results for Python $(python.version)"
+          - task: PublishCodeCoverageResults@2
+            inputs:
+                summaryFileLocation: "$(System.DefaultWorkingDirectory)/**/coverage.xml"


### PR DESCRIPTION
also reduce test pipelines to test three versions only. 3.9 as oldest version still provided with security fixes, and the two currently still regularly updated python versions 3.12 and 3.13. the extensive tests should now run on 3.13